### PR TITLE
fix: scope course listing by studio_id to prevent cross-tenant leak

### DIFF
--- a/server/src/controllers/attendanceController.ts
+++ b/server/src/controllers/attendanceController.ts
@@ -126,9 +126,16 @@ export class AttendanceController {
     const requestLog = req.logger!;
     requestLog.info({ query: req.query, userId: req.user!.id }, "Controller entry");
     try {
-      const studioId = req.studioId!;
+      const studioId = req.studioId;
       const { studentId } = req.query as { studentId?: string };
       const filters = AttendanceController.parseFilters(req);
+
+      // A new admin who hasn't created a studio yet has no studio_id. Without
+      // this guard the queries below would fetch across ALL studios (Prisma
+      // ignores an `undefined` studio_id filter). No studio → no data.
+      if (!studioId) {
+        return res.json({ mode: "session", items: [] });
+      }
 
       if (studentId) {
         const items = await AttendanceService.getStudentAttendanceOverview(

--- a/server/src/controllers/courseController.ts
+++ b/server/src/controllers/courseController.ts
@@ -16,7 +16,8 @@ export class CourseController {
 
       const courses = await CourseService.getAllCourses(
         userRole ?? undefined,
-        filters
+        filters,
+        req.studioId
       );
       requestLog.info(
         { count: courses?.length },

--- a/server/src/services/attendanceService.ts
+++ b/server/src/services/attendanceService.ts
@@ -270,6 +270,9 @@ export class AttendanceService {
     });
     serviceLogger.info({ studioId, filters }, "Fetching studio sessions");
 
+    // Tenant isolation: without a studio context, never fetch across studios.
+    if (!studioId) return [];
+
     const { from, to } = this.resolveWindow(filters.from, filters.to);
 
     const where: any = { studio_id: studioId, is_active: true };
@@ -310,6 +313,9 @@ export class AttendanceService {
       { studioId, studentId, filters },
       "Fetching student attendance overview"
     );
+
+    // Tenant isolation: without a studio context, never fetch across studios.
+    if (!studioId) return [];
 
     const classWhere: any = {};
     if (filters.instructorId) classWhere.instructor_id = filters.instructorId;

--- a/server/src/services/branchService.ts
+++ b/server/src/services/branchService.ts
@@ -18,16 +18,18 @@ export class BranchService {
   }
 
   static async create(studioId: string, data: BranchDTO) {
-    const branch = await prisma.branches.create({
-      data: {
-        studio_id: studioId,
-        ...data,
-      },
-    });
+    // Branch + default room must be created atomically. Without a transaction a
+    // failure on the room insert leaves an orphan branch (no room) behind.
+    return prisma.$transaction(async (tx) => {
+      const branch = await tx.branches.create({
+        data: {
+          studio_id: studioId,
+          ...data,
+        },
+      });
 
-    // Auto-create default room
-    if (branch) {
-      await prisma.studio_rooms.create({
+      // Auto-create default room
+      await tx.studio_rooms.create({
         data: {
           studio_id: studioId,
           branch_id: branch.id,
@@ -36,9 +38,9 @@ export class BranchService {
           is_active: true,
         },
       });
-    }
 
-    return branch;
+      return branch;
+    });
   }
 
   static async update(

--- a/server/src/services/courseService.ts
+++ b/server/src/services/courseService.ts
@@ -25,14 +25,28 @@ export class CourseService {
   /**
    * Get all courses with optional filters
    */
-  static async getAllCourses(userRole?: string, filters: CourseFilters = {}) {
+  static async getAllCourses(
+    userRole?: string,
+    filters: CourseFilters = {},
+    studioId?: string
+  ) {
     const serviceLogger = logger.child({
       service: "CourseService",
       method: "getAllCourses",
     });
-    serviceLogger.info({ userRole, filters }, "Fetching all courses");
+    serviceLogger.info({ userRole, filters, studioId }, "Fetching all courses");
 
-    const where: { is_active?: boolean; category_id?: string } = {};
+    // Tenant isolation: never return classes across studios. Callers without a
+    // studio context (e.g. SUPER_ADMIN) have nothing tenant-scoped to list here.
+    if (!studioId) {
+      return [];
+    }
+
+    const where: {
+      studio_id: string;
+      is_active?: boolean;
+      category_id?: string;
+    } = { studio_id: studioId };
 
     // If student or filter requests active only, show active courses
     if (userRole === "STUDENT" || filters.status === "active") {


### PR DESCRIPTION
GET /api/courses (CourseService.getAllCourses) had no studio_id filter, so it returned classes from every studio. This leaked other tenants' classes into the admin attendance class filter and four other screens (browse courses, enroll modal, student management, schedule). Thread req.studioId into getAllCourses and scope by it; callers without a studio context (SUPER_ADMIN) get an empty list.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>