### PR TITLE
fix: stop the admin screen from faking "no studio", repair schema drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,16 @@ docker compose exec backend npx prisma studio          # Open Prisma Studio GUI 
 docker compose exec db psql -U classly -d classly       # Postgres REPL
 ```
 
-> **No migrations directory exists.** Schema changes require: (1) edit `server/prisma/schema.prisma`, (2) run `ALTER TABLE ...` manually in psql, (3) `npx prisma generate`, (4) update `studio_management_schema_setup.sql` for fresh boots.
+> **No migrations directory exists.** Schema changes require: (1) edit `server/prisma/schema.prisma`, (2) run `ALTER TABLE ...` manually in psql, (3) `npx prisma generate`, (4) update `studio_management_schema_setup.sql` for fresh boots, (5) add the same change to `server/prisma/sql/2026-08-16_repair_schema_drift.sql` so existing databases get it too.
+
+> **`studio_management_schema_setup.sql` never runs on an existing database.** It is mounted at `/docker-entrypoint-initdb.d/setup.sql`, which Postgres executes only when the data directory is empty. Every edit made to it after the first boot is invisible to running environments, and Prisma names every column explicitly in its SQL — so one missing column makes *every* query on that table fail with a 500. Repair an environment with:
+>
+> ```bash
+> docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+>   < server/prisma/sql/2026-08-16_repair_schema_drift.sql
+> ```
+>
+> The script is idempotent and prints what it repaired.
 
 ## Architecture
 
@@ -157,6 +166,8 @@ Conventional commits: `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `test:`.
 - **`CourseService.getAllCourses`, `getCourseById`, `updateCourse` do not scope by `studio_id`** — cross-tenant data leak. Do not copy this pattern; it is a known CRITICAL defect tracked in `docs/ARCHITECTURE_REVIEW.md`.
 - **Prisma is mocked in all tests.** Green tests ≠ correct schema. Integration tests use Supertest against the real Express app but with mocked Prisma — schema drift is not caught.
 - **Invitation JWTs are stateless and reusable** until expiry. Do not use them as single-use tokens without adding DB-backed deduplication.
+- **A `SUPER_ADMIN` invite carries no studio** (`InvitationController.createInvite` passes the creator's `studio_id`, which is `NULL` for a super admin), so the invited `ADMIN` registers with `studio_id = NULL` and must create their studio through the onboarding form. `StudioService.getStudioForUser` re-links such a user through `studios.admin_id` once their studio exists.
+- **Never treat a failed request as "no data" in the admin screens.** `Administration` used to fall back to the studio-creation form on any error, so a 500 looked like a brand-new studio while every other tab showed the real data.
 - **`register` accepts `studio_serial`** without an invitation, silently creating a `STUDENT` in that studio.
 - **Auth state race condition in `App.tsx`:** `isAuthenticated`, `currentUser`, `userRole` update asynchronously. Default `userRole` is `'STUDENT'` so an admin may briefly see the wrong UI on load.
 - **No CI test gate.** Push to `main` deploys immediately to production via `.github/workflows/deploy.yml`. Treat `main` = production.

--- a/client/components/__tests__/Administration.test.tsx
+++ b/client/components/__tests__/Administration.test.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { HelmetProvider } from "react-helmet-async";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import "@testing-library/jest-dom";
+import { Administration } from "../admin/Administration/Administration";
+import {
+  StudioService,
+  BranchService,
+  RoomService,
+  UserService,
+} from "../../services/api";
+
+vi.mock("../../services/api", () => ({
+  StudioService: { getMyStudio: vi.fn(), create: vi.fn(), update: vi.fn() },
+  BranchService: { getAll: vi.fn(), delete: vi.fn() },
+  RoomService: { getAll: vi.fn(), getByBranch: vi.fn() },
+  UserService: { getInstructors: vi.fn() },
+  InvitationService: { createInvite: vi.fn() },
+}));
+
+const studio = {
+  id: "studio-1",
+  name: "סטודיו תל אביב",
+  serial_number: "260816-000001",
+};
+
+const renderAdministration = () =>
+  render(
+    <HelmetProvider>
+      <Administration />
+    </HelmetProvider>
+  );
+
+const axiosError = (status: number) => ({
+  response: { status, data: { message: "boom" } },
+  message: "Request failed",
+});
+
+const ONBOARDING_HEADING = "ברוכים הבאים ל-Classly!";
+
+describe("Administration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(BranchService.getAll).mockResolvedValue([]);
+    vi.mocked(RoomService.getAll).mockResolvedValue([]);
+    vi.mocked(UserService.getInstructors).mockResolvedValue([]);
+  });
+
+  it("shows the onboarding form only when the admin has no studio (404)", async () => {
+    vi.mocked(StudioService.getMyStudio).mockRejectedValue(axiosError(404));
+
+    renderAdministration();
+
+    expect(await screen.findByText(ONBOARDING_HEADING)).toBeInTheDocument();
+  });
+
+  it("shows an error instead of the onboarding form when the studio request fails", async () => {
+    // A 500 (e.g. a database column Prisma expects is missing) must not look
+    // like "this admin has no studio yet".
+    vi.mocked(StudioService.getMyStudio).mockRejectedValue(axiosError(500));
+
+    renderAdministration();
+
+    expect(await screen.findByText("boom")).toBeInTheDocument();
+    expect(screen.queryByText(ONBOARDING_HEADING)).not.toBeInTheDocument();
+  });
+
+  it("keeps showing the studio when a secondary request fails", async () => {
+    vi.mocked(StudioService.getMyStudio).mockResolvedValue(studio as any);
+    vi.mocked(BranchService.getAll).mockRejectedValue(axiosError(500));
+
+    renderAdministration();
+
+    await waitFor(() =>
+      expect(screen.getAllByText(studio.name).length).toBeGreaterThan(0)
+    );
+    expect(screen.queryByText(ONBOARDING_HEADING)).not.toBeInTheDocument();
+  });
+
+  it("renders the studio when everything loads", async () => {
+    vi.mocked(StudioService.getMyStudio).mockResolvedValue(studio as any);
+
+    renderAdministration();
+
+    await waitFor(() =>
+      expect(screen.getAllByText(studio.name).length).toBeGreaterThan(0)
+    );
+    expect(screen.getByText(studio.serial_number)).toBeInTheDocument();
+    expect(screen.queryByText(ONBOARDING_HEADING)).not.toBeInTheDocument();
+  });
+});

--- a/client/components/admin/Administration/Administration.tsx
+++ b/client/components/admin/Administration/Administration.tsx
@@ -8,6 +8,8 @@ import {
 } from "../../../services/api";
 import { Loader2, Building, MapPin, Clock } from "lucide-react";
 import { Studio, Branch, User, Room } from "../../../types/types";
+import { ErrorState } from "../../common/StateDisplay";
+import { extractApiError } from "../../../utils/apiError";
 
 import { StudioDetailsTab } from "./tabs/StudioDetailsTab";
 import { BranchManagementTab } from "./tabs/BranchManagementTab";
@@ -16,6 +18,7 @@ import { TeamManagementTab } from "./tabs/TeamManagementTab";
 export const Administration: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [studio, setStudio] = useState<Studio | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [branches, setBranches] = useState<Branch[]>([]);
   const [rooms, setRooms] = useState<Room[]>([]);
   const [instructors, setInstructors] = useState<User[]>([]);
@@ -29,6 +32,7 @@ export const Administration: React.FC = () => {
     name: "",
     description: "",
     contact_email: "",
+    contact_phone: "",
     website_url: "",
     schedule_start_hour: 7,
     schedule_end_hour: 23,
@@ -40,30 +44,54 @@ export const Administration: React.FC = () => {
   const [createError, setCreateError] = useState<string | null>(null);
 
   const fetchData = async () => {
+    setLoadError(null);
+
+    // The studio is loaded on its own: only a 404 means "this admin has no
+    // studio yet". Any other failure (a 500, a network error) must surface as
+    // an error — treating it as "no studio" showed the onboarding form to
+    // admins who already have a studio, branches and students.
     try {
       const studioData = await StudioService.getMyStudio();
       setStudio(studioData);
-
-      // Load branches
-      const branchesData = await BranchService.getAll();
-      setBranches(branchesData);
-
-      // Load Rooms
-      const roomsData = await RoomService.getAll();
-      setRooms(roomsData);
-
-      // Load Instructors
-      const instructorsData = await UserService.getInstructors();
-      setInstructors(instructorsData);
     } catch (err: any) {
-      if (err.response && err.response.status === 404) {
-        setStudio(null); // Show create form
-      } else {
-        console.error("Failed to load data", err);
+      setStudio(null);
+      if (err?.response?.status !== 404) {
+        console.error("Failed to load studio", err);
+        setLoadError(extractApiError(err, "שגיאה בטעינת נתוני הסטודיו"));
       }
-    } finally {
       setLoading(false);
+      return;
     }
+
+    // Secondary data. A failure in one of these must not hide the studio, so
+    // each result is applied independently.
+    const [branchesResult, roomsResult, instructorsResult] =
+      await Promise.allSettled([
+        BranchService.getAll(),
+        RoomService.getAll(),
+        UserService.getInstructors(),
+      ]);
+
+    if (branchesResult.status === "fulfilled")
+      setBranches(branchesResult.value);
+    else console.error("Failed to load branches", branchesResult.reason);
+
+    if (roomsResult.status === "fulfilled") setRooms(roomsResult.value);
+    else console.error("Failed to load rooms", roomsResult.reason);
+
+    if (instructorsResult.status === "fulfilled")
+      setInstructors(instructorsResult.value);
+    else console.error("Failed to load instructors", instructorsResult.reason);
+
+    if (
+      [branchesResult, roomsResult, instructorsResult].some(
+        (r) => r.status === "rejected"
+      )
+    ) {
+      setLoadError("חלק מהנתונים לא נטענו. רענן את הדף או נסה שוב.");
+    }
+
+    setLoading(false);
   };
 
   useEffect(() => {
@@ -92,20 +120,35 @@ export const Administration: React.FC = () => {
       await StudioService.create(payload);
       await fetchData();
     } catch (err: any) {
-      setCreateError(
-        err.response?.data?.error || err.message || "שגיאה ביצירת הסטודיו"
-      );
+      setCreateError(extractApiError(err, "שגיאה ביצירת הסטודיו"));
     } finally {
       setLoading(false);
     }
   };
 
-  if (loading && !studio && !createForm.name)
+  if (loading)
     return (
       <div className="flex justify-center p-8">
         <Loader2 className="animate-spin text-indigo-600" />
       </div>
     );
+
+  // View 0: The studio could not be loaded. Never fall through to onboarding
+  // here — offering to create a studio that may already exist is what made
+  // this screen contradict the rest of the app.
+  if (loadError && !studio) {
+    return (
+      <div className="py-8">
+        <ErrorState
+          message={loadError}
+          onRetry={() => {
+            setLoading(true);
+            fetchData();
+          }}
+        />
+      </div>
+    );
+  }
 
   // View 1: Create Studio Form (Onboarding)
   if (!studio) {
@@ -114,7 +157,10 @@ export const Administration: React.FC = () => {
         <div className="bg-white dark:bg-slate-900 p-8 rounded-xl shadow-lg border border-indigo-100 dark:border-slate-800">
           <div className="text-center mb-8">
             <div className="bg-indigo-100 dark:bg-indigo-900/50 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
-              <Building className="text-indigo-600 dark:text-indigo-400" size={32} />
+              <Building
+                className="text-indigo-600 dark:text-indigo-400"
+                size={32}
+              />
             </div>
             <h2 className="text-2xl font-bold text-slate-800 dark:text-slate-100">
               ברוכים הבאים ל-Classly!
@@ -173,7 +219,7 @@ export const Administration: React.FC = () => {
                   />
                 </div>
               </div>
-              
+
               <h3 className="font-semibold text-slate-700 dark:text-slate-300 mt-4 mb-3 flex items-center gap-2">
                 <Clock size={18} /> שעות פעילות הסטודיו
               </h3>
@@ -319,11 +365,18 @@ export const Administration: React.FC = () => {
         <title>ניהול | Classly</title>
       </Helmet>
 
+      {loadError && (
+        <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-300 p-3 rounded-lg text-sm">
+          {loadError}
+        </div>
+      )}
+
       {/* Header */}
       <div className="bg-white dark:bg-slate-900 p-6 rounded-xl shadow-sm border border-slate-100 dark:border-slate-800 flex justify-between items-center">
         <div>
           <h2 className="text-2xl font-bold text-slate-800 dark:text-slate-100 flex items-center gap-2">
-            <Building className="text-indigo-600 dark:text-indigo-400" /> {studio.name}
+            <Building className="text-indigo-600 dark:text-indigo-400" />{" "}
+            {studio.name}
           </h2>
           <p className="text-slate-500 dark:text-slate-400 text-sm">
             מספר סידורי:{" "}

--- a/client/utils/apiError.ts
+++ b/client/utils/apiError.ts
@@ -1,0 +1,16 @@
+/**
+ * Pull a human-readable message out of an Axios error.
+ *
+ * The API answers with `{ error }` from controllers and `{ status, message }`
+ * from errorMiddleware, so both shapes have to be handled — reading only
+ * `data.error` silently swallowed every error the middleware produced.
+ */
+export const extractApiError = (err: any, fallback: string): string => {
+  const data = err?.response?.data;
+  if (typeof data === "string" && data.trim()) return data;
+
+  const message = data?.error || data?.message;
+  if (typeof message === "string" && message.trim()) return message;
+
+  return fallback;
+};

--- a/server/prisma/sql/2026-08-16_repair_schema_drift.sql
+++ b/server/prisma/sql/2026-08-16_repair_schema_drift.sql
@@ -336,23 +336,45 @@ $checks$;
 
 -- ---------------------------------------------------------------------------
 -- 4. Indexes (no-ops when they already exist)
+--
+-- Guarded the same way as the column loop: a database missing a whole table
+-- gets a warning, not an error that stops psql (`-v ON_ERROR_STOP=1`) before
+-- the remaining indexes and the verification queries have run.
 -- ---------------------------------------------------------------------------
-CREATE INDEX IF NOT EXISTS idx_users_email ON public.users(email);
-CREATE INDEX IF NOT EXISTS idx_users_studio_id ON public.users(studio_id);
-CREATE INDEX IF NOT EXISTS idx_users_role ON public.users(role);
-CREATE INDEX IF NOT EXISTS idx_studios_admin_id ON public.studios(admin_id);
-CREATE INDEX IF NOT EXISTS idx_studios_serial ON public.studios(serial_number);
-CREATE INDEX IF NOT EXISTS idx_branches_studio_id ON public.branches(studio_id);
-CREATE INDEX IF NOT EXISTS idx_categories_studio_id ON public.categories(studio_id);
-CREATE INDEX IF NOT EXISTS idx_classes_studio_id ON public.classes(studio_id);
-CREATE INDEX IF NOT EXISTS idx_classes_branch_id ON public.classes(branch_id);
-CREATE INDEX IF NOT EXISTS idx_classes_instructor_id ON public.classes(instructor_id);
-CREATE INDEX IF NOT EXISTS idx_enrollments_student_id ON public.enrollments(student_id);
-CREATE INDEX IF NOT EXISTS idx_enrollments_class_id ON public.enrollments(class_id);
-CREATE INDEX IF NOT EXISTS idx_attendance_student_id ON public.attendance(student_id);
-CREATE INDEX IF NOT EXISTS idx_attendance_class_id ON public.attendance(class_id);
-CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_user_id ON public.password_reset_tokens(user_id);
-CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_hash ON public.password_reset_tokens(token_hash) WHERE NOT used;
+DO $indexes$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT * FROM (VALUES
+    ('users', 'CREATE INDEX IF NOT EXISTS idx_users_email ON public.users(email)'),
+    ('users', 'CREATE INDEX IF NOT EXISTS idx_users_studio_id ON public.users(studio_id)'),
+    ('users', 'CREATE INDEX IF NOT EXISTS idx_users_role ON public.users(role)'),
+    ('studios', 'CREATE INDEX IF NOT EXISTS idx_studios_admin_id ON public.studios(admin_id)'),
+    ('studios', 'CREATE INDEX IF NOT EXISTS idx_studios_serial ON public.studios(serial_number)'),
+    ('branches', 'CREATE INDEX IF NOT EXISTS idx_branches_studio_id ON public.branches(studio_id)'),
+    ('categories', 'CREATE INDEX IF NOT EXISTS idx_categories_studio_id ON public.categories(studio_id)'),
+    ('classes', 'CREATE INDEX IF NOT EXISTS idx_classes_studio_id ON public.classes(studio_id)'),
+    ('classes', 'CREATE INDEX IF NOT EXISTS idx_classes_branch_id ON public.classes(branch_id)'),
+    ('classes', 'CREATE INDEX IF NOT EXISTS idx_classes_instructor_id ON public.classes(instructor_id)'),
+    ('enrollments', 'CREATE INDEX IF NOT EXISTS idx_enrollments_student_id ON public.enrollments(student_id)'),
+    ('enrollments', 'CREATE INDEX IF NOT EXISTS idx_enrollments_class_id ON public.enrollments(class_id)'),
+    ('attendance', 'CREATE INDEX IF NOT EXISTS idx_attendance_student_id ON public.attendance(student_id)'),
+    ('attendance', 'CREATE INDEX IF NOT EXISTS idx_attendance_class_id ON public.attendance(class_id)'),
+    ('password_reset_tokens', 'CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_user_id ON public.password_reset_tokens(user_id)'),
+    ('password_reset_tokens', 'CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_hash ON public.password_reset_tokens(token_hash) WHERE NOT used'),
+    ('pending_registrations', 'CREATE INDEX IF NOT EXISTS idx_pending_registrations_email ON public.pending_registrations(email) WHERE NOT used')
+    ) AS t(tbl, stmt)
+  LOOP
+    IF to_regclass('public.' || quote_ident(r.tbl)) IS NULL THEN
+      RAISE WARNING 'skipping index on missing table public.%', r.tbl;
+      CONTINUE;
+    END IF;
+
+    EXECUTE r.stmt;
+  END LOOP;
+END
+$indexes$;
 
 -- ---------------------------------------------------------------------------
 -- 5. Verification

--- a/server/prisma/sql/2026-08-16_repair_schema_drift.sql
+++ b/server/prisma/sql/2026-08-16_repair_schema_drift.sql
@@ -24,8 +24,16 @@
 -- Any other column the setup script has gained since is repaired as well: the
 -- list below covers every column of every table.
 --
--- HOW TO RUN (from the repo root on the server):
---   docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+-- HOW TO RUN (from the repo root on the server). The production stack runs
+-- under the `classly-studio` compose project, so plain `docker compose exec`
+-- from a checkout reports "service db is not running" — address the container
+-- by name instead:
+--   docker exec -i classly-db psql -U itay -d classly_db -v ON_ERROR_STOP=1 \
+--     < server/prisma/sql/2026-08-16_repair_schema_drift.sql
+--
+-- The equivalent through compose:
+--   docker compose --project-name classly-studio exec -T db \
+--     psql -U itay -d classly_db -v ON_ERROR_STOP=1 \
 --     < server/prisma/sql/2026-08-16_repair_schema_drift.sql
 --
 -- Nothing here drops data: only ADD COLUMN IF NOT EXISTS, CREATE ... IF NOT
@@ -249,6 +257,11 @@ BEGIN
 END
 $repair$;
 
+COMMIT;
+
+-- The column repair is committed above on purpose: everything that follows
+-- runs in its own transaction, so a problem there can never roll it back.
+
 -- ---------------------------------------------------------------------------
 -- 2. Serial-number sequence used by StudioService.createStudio()
 -- ---------------------------------------------------------------------------
@@ -289,7 +302,17 @@ BEGIN
       ADD CONSTRAINT schedule_sessions_status_check
       CHECK (status IN ('SCHEDULED', 'CANCELLED', 'COMPLETED', 'RESCHEDULED', 'IN_PROGRESS'));
   END IF;
+EXCEPTION WHEN others THEN
+  -- Legacy rows holding a status outside the list would abort the ALTER.
+  -- Report it instead of failing the whole repair.
+  RAISE WARNING 'could not refresh schedule_sessions.status check: %', SQLERRM;
+END
+$checks$;
 
+DO $checks$
+DECLARE
+  c record;
+BEGIN
   -- enrollments.status must accept PENDING (enrollment awaiting payment)
   IF to_regclass('public.enrollments') IS NOT NULL THEN
     FOR c IN
@@ -306,6 +329,8 @@ BEGIN
       ADD CONSTRAINT enrollments_status_check
       CHECK (status IN ('ACTIVE', 'PAUSED', 'COMPLETED', 'CANCELLED', 'PENDING'));
   END IF;
+EXCEPTION WHEN others THEN
+  RAISE WARNING 'could not refresh enrollments.status check: %', SQLERRM;
 END
 $checks$;
 
@@ -328,8 +353,6 @@ CREATE INDEX IF NOT EXISTS idx_attendance_student_id ON public.attendance(studen
 CREATE INDEX IF NOT EXISTS idx_attendance_class_id ON public.attendance(class_id);
 CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_user_id ON public.password_reset_tokens(user_id);
 CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_hash ON public.password_reset_tokens(token_hash) WHERE NOT used;
-
-COMMIT;
 
 -- ---------------------------------------------------------------------------
 -- 5. Verification

--- a/server/prisma/sql/2026-08-16_repair_schema_drift.sql
+++ b/server/prisma/sql/2026-08-16_repair_schema_drift.sql
@@ -1,0 +1,355 @@
+-- ============================================================================
+-- Schema drift repair — safe to run repeatedly, on any environment.
+--
+-- WHY THIS FILE EXISTS
+-- studio_management_schema_setup.sql is mounted into the db container at
+-- /docker-entrypoint-initdb.d/setup.sql, so Postgres runs it ONLY when the data
+-- directory is empty (a brand-new volume). Every schema change made to that
+-- file after the first boot never reaches an existing database, and the repo
+-- has no migrations directory. The result is drift: Prisma's models list
+-- columns the live database does not have, and because Prisma names every
+-- column explicitly in its SELECT/INSERT statements, a single missing column
+-- makes every query against that table fail with `column ... does not exist`
+-- (surfacing as HTTP 500).
+--
+-- Known drift this repairs:
+--   * studios.schedule_start_hour / schedule_end_hour  (added 2026-06-03)
+--     -> breaks GET /api/studios/my-studio and POST /api/studios on every
+--        database created before that date.
+--   * schedule_sessions.status CHECK missing 'IN_PROGRESS'  (added 2026-08-16)
+--     -> breaks saving attendance with sessionStatus = IN_PROGRESS.
+--   * enrollments.status CHECK missing 'PENDING'  (added 2026-03-11)
+--   * public.studio_serial_sequence  (added 2026-03-10)
+--     -> studio creation cannot generate a serial number without it.
+-- Any other column the setup script has gained since is repaired as well: the
+-- list below covers every column of every table.
+--
+-- HOW TO RUN (from the repo root on the server):
+--   docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+--     < server/prisma/sql/2026-08-16_repair_schema_drift.sql
+--
+-- Nothing here drops data: only ADD COLUMN IF NOT EXISTS, CREATE ... IF NOT
+-- EXISTS, and CHECK constraint definitions being refreshed.
+-- ============================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. Columns the live schema may be missing
+-- ---------------------------------------------------------------------------
+DO $repair$
+DECLARE
+  r       record;
+  added   int := 0;
+  skipped int := 0;
+BEGIN
+  FOR r IN
+    SELECT * FROM (VALUES
+    ('studios', 'name', 'VARCHAR(255)'),
+    ('studios', 'serial_number', 'VARCHAR(20)'),
+    ('studios', 'description', 'TEXT'),
+    ('studios', 'admin_id', 'UUID'),
+    ('studios', 'contact_email', 'VARCHAR(255)'),
+    ('studios', 'contact_phone', 'VARCHAR(20)'),
+    ('studios', 'website_url', 'TEXT'),
+    ('studios', 'bank_account_holder', 'VARCHAR(255)'),
+    ('studios', 'bank_account_number', 'VARCHAR(50)'),
+    ('studios', 'bank_code', 'VARCHAR(10)'),
+    ('studios', 'cancellation_deadline_hours', 'INTEGER DEFAULT 24'),
+    ('studios', 'refund_percentage', 'DECIMAL(5, 2) DEFAULT 0'),
+    ('studios', 'schedule_start_hour', 'INTEGER DEFAULT 7'),
+    ('studios', 'schedule_end_hour', 'INTEGER DEFAULT 23'),
+    ('studios', 'is_active', 'BOOLEAN DEFAULT true'),
+    ('studios', 'created_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('studios', 'updated_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('branches', 'studio_id', 'UUID REFERENCES public.studios(id) ON DELETE CASCADE'),
+    ('branches', 'name', 'VARCHAR(255) NOT NULL DEFAULT ''Main Branch'''),
+    ('branches', 'address', 'VARCHAR(255)'),
+    ('branches', 'city', 'VARCHAR(100)'),
+    ('branches', 'coordinates', 'POINT'),
+    ('branches', 'phone_number', 'VARCHAR(20)'),
+    ('branches', 'is_active', 'BOOLEAN DEFAULT true'),
+    ('branches', 'created_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('branches', 'updated_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('studio_rooms', 'studio_id', 'UUID REFERENCES public.studios(id) ON DELETE CASCADE'),
+    ('studio_rooms', 'branch_id', 'UUID REFERENCES public.branches(id) ON DELETE CASCADE'),
+    ('studio_rooms', 'name', 'VARCHAR(255)'),
+    ('studio_rooms', 'capacity', 'INTEGER'),
+    ('studio_rooms', 'is_active', 'BOOLEAN DEFAULT true'),
+    ('studio_rooms', 'created_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('studio_rooms', 'updated_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('pending_registrations', 'email', 'VARCHAR(255)'),
+    ('pending_registrations', 'studio_id', 'UUID REFERENCES public.studios(id) ON DELETE CASCADE'),
+    ('pending_registrations', 'invitation_token', 'VARCHAR(500)'),
+    ('pending_registrations', 'role', 'VARCHAR(20) CHECK (role IS NULL OR role IN (''ADMIN'', ''INSTRUCTOR'', ''SUPER_ADMIN''))'),
+    ('pending_registrations', 'validated_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('pending_registrations', 'expires_at', 'TIMESTAMP WITH TIME ZONE DEFAULT (NOW() + INTERVAL ''1 hour'')'),
+    ('pending_registrations', 'used', 'BOOLEAN DEFAULT false'),
+    ('pending_registrations', 'created_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('users', 'email', 'VARCHAR(255)'),
+    ('users', 'password_hash', 'TEXT'),
+    ('users', 'full_name', 'VARCHAR(255)'),
+    ('users', 'phone_number', 'VARCHAR(20)'),
+    ('users', 'profile_image_url', 'TEXT'),
+    ('users', 'role', 'VARCHAR(20) CHECK (role IN (''SUPER_ADMIN'', ''ADMIN'', ''INSTRUCTOR'', ''STUDENT'', ''PARENT'')) DEFAULT ''STUDENT'''),
+    ('users', 'studio_id', 'UUID REFERENCES public.studios(id) ON DELETE SET NULL'),
+    ('users', 'status', 'VARCHAR(20) CHECK (status IN (''ACTIVE'', ''INACTIVE'', ''SUSPENDED'')) DEFAULT ''ACTIVE'''),
+    ('users', 'last_login_at', 'TIMESTAMP WITH TIME ZONE'),
+    ('users', 'login_count', 'INTEGER DEFAULT 0'),
+    ('users', 'preferences', 'JSONB DEFAULT ''{}''::jsonb'),
+    ('users', 'created_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('users', 'updated_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('categories', 'studio_id', 'UUID REFERENCES public.studios(id) ON DELETE CASCADE'),
+    ('categories', 'name', 'VARCHAR(255)'),
+    ('categories', 'description', 'TEXT'),
+    ('categories', 'color', 'VARCHAR(7)'),
+    ('categories', 'icon', 'VARCHAR(50)'),
+    ('categories', 'type', 'VARCHAR(20) CHECK (type IN (''ARTS'', ''SPORTS'', ''WELLNESS'', ''ACADEMIC''))'),
+    ('categories', 'sort_order', 'INTEGER DEFAULT 0'),
+    ('categories', 'is_active', 'BOOLEAN DEFAULT true'),
+    ('categories', 'created_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('categories', 'updated_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('classes', 'studio_id', 'UUID REFERENCES public.studios(id) ON DELETE CASCADE'),
+    ('classes', 'branch_id', 'UUID REFERENCES public.branches(id) ON DELETE SET NULL'),
+    ('classes', 'category_id', 'UUID REFERENCES public.categories(id) ON DELETE SET NULL'),
+    ('classes', 'name', 'VARCHAR(255)'),
+    ('classes', 'description', 'TEXT'),
+    ('classes', 'instructor_id', 'UUID REFERENCES public.users(id)'),
+    ('classes', 'day_of_week', 'INTEGER CHECK (day_of_week >= 0 AND day_of_week <= 6)'),
+    ('classes', 'start_time', 'TIME'),
+    ('classes', 'end_time', 'TIME'),
+    ('classes', 'timezone', 'VARCHAR(50) DEFAULT ''Asia/Jerusalem'''),
+    ('classes', 'location_room', 'VARCHAR(100)'),
+    ('classes', 'location_building', 'VARCHAR(100)'),
+    ('classes', 'max_capacity', 'INTEGER CHECK (max_capacity > 0)'),
+    ('classes', 'current_enrollment', 'INTEGER DEFAULT 0'),
+    ('classes', 'age_range_min', 'INTEGER'),
+    ('classes', 'age_range_max', 'INTEGER'),
+    ('classes', 'level', 'VARCHAR(20) CHECK (level IN (''BEGINNER'', ''INTERMEDIATE'', ''ADVANCED'', ''ALL_LEVELS''))'),
+    ('classes', 'price_ils', 'DECIMAL(10, 2) CHECK (price_ils >= 0)'),
+    ('classes', 'billing_cycle', 'VARCHAR(20) CHECK (billing_cycle IN (''MONTHLY'', ''SEMESTER'', ''YEARLY''))'),
+    ('classes', 'is_active', 'BOOLEAN DEFAULT true'),
+    ('classes', 'created_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('classes', 'updated_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('classes', 'room_id', 'UUID REFERENCES public.studio_rooms(id) ON DELETE SET NULL'),
+    ('enrollments', 'studio_id', 'UUID REFERENCES public.studios(id) ON DELETE CASCADE'),
+    ('enrollments', 'student_id', 'UUID REFERENCES public.users(id) ON DELETE CASCADE'),
+    ('enrollments', 'class_id', 'UUID REFERENCES public.classes(id) ON DELETE CASCADE'),
+    ('enrollments', 'parent_id', 'UUID REFERENCES public.users(id) ON DELETE SET NULL'),
+    ('enrollments', 'enrollment_date', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('enrollments', 'status', 'VARCHAR(20) CHECK (status IN (''ACTIVE'', ''PAUSED'', ''COMPLETED'', ''CANCELLED'', ''PENDING'')) DEFAULT ''ACTIVE'''),
+    ('enrollments', 'payment_status', 'VARCHAR(20) CHECK (payment_status IN (''PENDING'', ''PAID'', ''PARTIAL'', ''OVERDUE'')) DEFAULT ''PENDING'''),
+    ('enrollments', 'total_amount_due', 'DECIMAL(10, 2) NOT NULL DEFAULT 0'),
+    ('enrollments', 'total_amount_paid', 'DECIMAL(10, 2) NOT NULL DEFAULT 0'),
+    ('enrollments', 'start_date', 'DATE'),
+    ('enrollments', 'end_date', 'DATE'),
+    ('enrollments', 'cancellation_reason', 'TEXT'),
+    ('enrollments', 'notes', 'TEXT'),
+    ('enrollments', 'created_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('enrollments', 'updated_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('attendance', 'studio_id', 'UUID REFERENCES public.studios(id) ON DELETE CASCADE'),
+    ('attendance', 'class_id', 'UUID REFERENCES public.classes(id) ON DELETE CASCADE'),
+    ('attendance', 'instructor_id', 'UUID REFERENCES public.users(id)'),
+    ('attendance', 'enrollment_id', 'UUID REFERENCES public.enrollments(id) ON DELETE SET NULL'),
+    ('attendance', 'student_id', 'UUID REFERENCES public.users(id)'),
+    ('attendance', 'session_date', 'DATE'),
+    ('attendance', 'status', 'VARCHAR(20) CHECK (status IN (''PRESENT'', ''ABSENT'', ''EXCUSED'', ''LATE'')) DEFAULT ''ABSENT'''),
+    ('attendance', 'notes', 'TEXT'),
+    ('attendance', 'recorded_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('attendance', 'recorded_by', 'UUID REFERENCES public.users(id)'),
+    ('attendance', 'created_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('attendance', 'updated_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('payments', 'studio_id', 'UUID REFERENCES public.studios(id) ON DELETE CASCADE'),
+    ('payments', 'enrollment_id', 'UUID REFERENCES public.enrollments(id) ON DELETE SET NULL'),
+    ('payments', 'student_id', 'UUID REFERENCES public.users(id)'),
+    ('payments', 'instructor_id', 'UUID REFERENCES public.users(id) ON DELETE SET NULL'),
+    ('payments', 'amount_ils', 'DECIMAL(10, 2) CHECK (amount_ils > 0)'),
+    ('payments', 'amount_cents', 'INTEGER'),
+    ('payments', 'currency', 'VARCHAR(3) DEFAULT ''ILS'''),
+    ('payments', 'payment_method', 'VARCHAR(50) CHECK (payment_method IN (''CREDIT_CARD'', ''BANK_TRANSFER'', ''CHECK'', ''CASH'', ''STRIPE''))'),
+    ('payments', 'transzilla_transaction_id', 'VARCHAR(100)'),
+    ('payments', 'stripe_payment_intent_id', 'VARCHAR(255)'),
+    ('payments', 'stripe_charge_id', 'VARCHAR(255)'),
+    ('payments', 'status', 'VARCHAR(20) CHECK (status IN (''PENDING'', ''COMPLETED'', ''FAILED'', ''REFUNDED'', ''SUCCEEDED'')) DEFAULT ''PENDING'''),
+    ('payments', 'invoice_number', 'VARCHAR(50)'),
+    ('payments', 'invoice_url', 'TEXT'),
+    ('payments', 'due_date', 'DATE'),
+    ('payments', 'paid_date', 'TIMESTAMP WITH TIME ZONE'),
+    ('payments', 'refund_date', 'TIMESTAMP WITH TIME ZONE'),
+    ('payments', 'refund_reason', 'TEXT'),
+    ('payments', 'notes', 'TEXT'),
+    ('payments', 'created_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('payments', 'updated_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('instructor_commissions', 'studio_id', 'UUID REFERENCES public.studios(id) ON DELETE CASCADE'),
+    ('instructor_commissions', 'instructor_id', 'UUID REFERENCES public.users(id)'),
+    ('instructor_commissions', 'class_id', 'UUID REFERENCES public.classes(id)'),
+    ('instructor_commissions', 'commission_percentage', 'DECIMAL(5, 2)'),
+    ('instructor_commissions', 'commission_fixed', 'DECIMAL(10, 2)'),
+    ('instructor_commissions', 'billing_cycle', 'VARCHAR(20) CHECK (billing_cycle IN (''PER_SESSION'', ''MONTHLY'', ''QUARTERLY''))'),
+    ('instructor_commissions', 'payment_status', 'VARCHAR(20) CHECK (payment_status IN (''PENDING'', ''PAID'', ''OVERDUE'')) DEFAULT ''PENDING'''),
+    ('instructor_commissions', 'total_earned', 'DECIMAL(10, 2) DEFAULT 0'),
+    ('instructor_commissions', 'total_paid', 'DECIMAL(10, 2) DEFAULT 0'),
+    ('instructor_commissions', 'last_payment_date', 'TIMESTAMP WITH TIME ZONE'),
+    ('instructor_commissions', 'created_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('instructor_commissions', 'updated_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('schedule_sessions', 'studio_id', 'UUID REFERENCES public.studios(id) ON DELETE CASCADE'),
+    ('schedule_sessions', 'class_id', 'UUID REFERENCES public.classes(id) ON DELETE CASCADE'),
+    ('schedule_sessions', 'session_date', 'DATE'),
+    ('schedule_sessions', 'start_time', 'TIME'),
+    ('schedule_sessions', 'end_time', 'TIME'),
+    ('schedule_sessions', 'location_room', 'VARCHAR(100)'),
+    ('schedule_sessions', 'capacity', 'INTEGER'),
+    ('schedule_sessions', 'enrollment_count', 'INTEGER DEFAULT 0'),
+    ('schedule_sessions', 'status', 'VARCHAR(20) DEFAULT ''SCHEDULED'''),
+    ('schedule_sessions', 'notes', 'TEXT'),
+    ('schedule_sessions', 'created_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('schedule_sessions', 'updated_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('notifications', 'user_id', 'UUID REFERENCES public.users(id) ON DELETE CASCADE'),
+    ('notifications', 'studio_id', 'UUID REFERENCES public.studios(id) ON DELETE CASCADE'),
+    ('notifications', 'type', 'VARCHAR(50) CHECK (type IN (''SCHEDULE_CHANGE'', ''PAYMENT_DUE'', ''ENROLLMENT_CONFIRMED'', ''SYSTEM''))'),
+    ('notifications', 'title', 'VARCHAR(255)'),
+    ('notifications', 'message', 'TEXT'),
+    ('notifications', 'related_entity_id', 'UUID'),
+    ('notifications', 'is_read', 'BOOLEAN DEFAULT false'),
+    ('notifications', 'read_at', 'TIMESTAMP WITH TIME ZONE'),
+    ('notifications', 'created_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('audit_logs', 'studio_id', 'UUID REFERENCES public.studios(id) ON DELETE CASCADE'),
+    ('audit_logs', 'user_id', 'UUID REFERENCES public.users(id)'),
+    ('audit_logs', 'action', 'VARCHAR(100)'),
+    ('audit_logs', 'table_name', 'VARCHAR(100)'),
+    ('audit_logs', 'record_id', 'UUID'),
+    ('audit_logs', 'changes', 'JSONB'),
+    ('audit_logs', 'ip_address', 'INET'),
+    ('audit_logs', 'user_agent', 'TEXT'),
+    ('audit_logs', 'created_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()'),
+    ('password_reset_tokens', 'user_id', 'UUID REFERENCES public.users(id) ON DELETE CASCADE'),
+    ('password_reset_tokens', 'token_hash', 'VARCHAR(255)'),
+    ('password_reset_tokens', 'used', 'BOOLEAN DEFAULT false'),
+    ('password_reset_tokens', 'expires_at', 'TIMESTAMP WITH TIME ZONE'),
+    ('password_reset_tokens', 'created_at', 'TIMESTAMP WITH TIME ZONE DEFAULT NOW()')
+    ) AS t(tbl, col, coldef)
+  LOOP
+    IF to_regclass('public.' || quote_ident(r.tbl)) IS NULL THEN
+      RAISE WARNING 'table public.% is missing entirely — run the full setup script on a fresh volume', r.tbl;
+      skipped := skipped + 1;
+      CONTINUE;
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = r.tbl AND column_name = r.col
+    ) THEN
+      RAISE NOTICE 'adding missing column %.%', r.tbl, r.col;
+      EXECUTE format('ALTER TABLE public.%I ADD COLUMN %I %s', r.tbl, r.col, r.coldef);
+      added := added + 1;
+    END IF;
+  END LOOP;
+
+  RAISE NOTICE 'columns added: %, missing tables: %', added, skipped;
+END
+$repair$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Serial-number sequence used by StudioService.createStudio()
+-- ---------------------------------------------------------------------------
+CREATE SEQUENCE IF NOT EXISTS public.studio_serial_sequence START 1;
+
+-- Never hand out a serial that already exists (studios.serial_number is UNIQUE).
+SELECT setval(
+  'public.studio_serial_sequence',
+  GREATEST(
+    (SELECT last_value FROM public.studio_serial_sequence),
+    COALESCE((
+      SELECT MAX(split_part(serial_number, '-', 2)::bigint)
+      FROM public.studios
+      WHERE serial_number ~ '^[0-9]{6}-[0-9]+$'
+    ), 0)
+  )
+);
+
+-- ---------------------------------------------------------------------------
+-- 3. CHECK constraints that gained allowed values after the initial boot
+-- ---------------------------------------------------------------------------
+DO $checks$
+DECLARE
+  c record;
+BEGIN
+  -- schedule_sessions.status must accept IN_PROGRESS (attendance saved mid-class)
+  IF to_regclass('public.schedule_sessions') IS NOT NULL THEN
+    FOR c IN
+      SELECT conname FROM pg_constraint
+      WHERE conrelid = 'public.schedule_sessions'::regclass
+        AND contype = 'c'
+        AND pg_get_constraintdef(oid) ILIKE '%status%'
+    LOOP
+      EXECUTE format('ALTER TABLE public.schedule_sessions DROP CONSTRAINT %I', c.conname);
+    END LOOP;
+
+    ALTER TABLE public.schedule_sessions
+      ADD CONSTRAINT schedule_sessions_status_check
+      CHECK (status IN ('SCHEDULED', 'CANCELLED', 'COMPLETED', 'RESCHEDULED', 'IN_PROGRESS'));
+  END IF;
+
+  -- enrollments.status must accept PENDING (enrollment awaiting payment)
+  IF to_regclass('public.enrollments') IS NOT NULL THEN
+    FOR c IN
+      SELECT conname FROM pg_constraint
+      WHERE conrelid = 'public.enrollments'::regclass
+        AND contype = 'c'
+        AND pg_get_constraintdef(oid) ILIKE '%status%'
+        AND pg_get_constraintdef(oid) NOT ILIKE '%payment_status%'
+    LOOP
+      EXECUTE format('ALTER TABLE public.enrollments DROP CONSTRAINT %I', c.conname);
+    END LOOP;
+
+    ALTER TABLE public.enrollments
+      ADD CONSTRAINT enrollments_status_check
+      CHECK (status IN ('ACTIVE', 'PAUSED', 'COMPLETED', 'CANCELLED', 'PENDING'));
+  END IF;
+END
+$checks$;
+
+-- ---------------------------------------------------------------------------
+-- 4. Indexes (no-ops when they already exist)
+-- ---------------------------------------------------------------------------
+CREATE INDEX IF NOT EXISTS idx_users_email ON public.users(email);
+CREATE INDEX IF NOT EXISTS idx_users_studio_id ON public.users(studio_id);
+CREATE INDEX IF NOT EXISTS idx_users_role ON public.users(role);
+CREATE INDEX IF NOT EXISTS idx_studios_admin_id ON public.studios(admin_id);
+CREATE INDEX IF NOT EXISTS idx_studios_serial ON public.studios(serial_number);
+CREATE INDEX IF NOT EXISTS idx_branches_studio_id ON public.branches(studio_id);
+CREATE INDEX IF NOT EXISTS idx_categories_studio_id ON public.categories(studio_id);
+CREATE INDEX IF NOT EXISTS idx_classes_studio_id ON public.classes(studio_id);
+CREATE INDEX IF NOT EXISTS idx_classes_branch_id ON public.classes(branch_id);
+CREATE INDEX IF NOT EXISTS idx_classes_instructor_id ON public.classes(instructor_id);
+CREATE INDEX IF NOT EXISTS idx_enrollments_student_id ON public.enrollments(student_id);
+CREATE INDEX IF NOT EXISTS idx_enrollments_class_id ON public.enrollments(class_id);
+CREATE INDEX IF NOT EXISTS idx_attendance_student_id ON public.attendance(student_id);
+CREATE INDEX IF NOT EXISTS idx_attendance_class_id ON public.attendance(class_id);
+CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_user_id ON public.password_reset_tokens(user_id);
+CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_hash ON public.password_reset_tokens(token_hash) WHERE NOT used;
+
+COMMIT;
+
+-- ---------------------------------------------------------------------------
+-- 5. Verification
+-- ---------------------------------------------------------------------------
+\echo '--- studios columns (schedule_start_hour + schedule_end_hour must be present) ---'
+SELECT column_name, data_type, column_default
+FROM information_schema.columns
+WHERE table_schema = 'public' AND table_name = 'studios'
+ORDER BY ordinal_position;
+
+\echo '--- admins pointing at a studio row that does not exist (expect 0 rows) ---'
+SELECT u.id AS user_id, u.email, u.studio_id
+FROM public.users u
+LEFT JOIN public.studios s ON s.id = u.studio_id
+WHERE u.role IN ('ADMIN', 'SUPER_ADMIN')
+  AND u.studio_id IS NOT NULL
+  AND s.id IS NULL;
+
+\echo '--- admins who own a studio but are not linked to it (self-heals on next load) ---'
+SELECT u.id AS user_id, u.email, s.id AS owned_studio_id, u.studio_id AS linked_studio_id
+FROM public.users u
+JOIN public.studios s ON s.admin_id = u.id
+WHERE u.studio_id IS DISTINCT FROM s.id;

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -140,3 +140,7 @@ app.get("/api/health", (req, res) => {
 });
 
 app.use(errorHandler);
+
+// Both forms are in use: src/index.ts imports the named export, the
+// integration tests import the default one.
+export default app;

--- a/server/src/controllers/branchController.ts
+++ b/server/src/controllers/branchController.ts
@@ -1,66 +1,67 @@
-
-import { Request, Response, NextFunction } from 'express';
-import { BranchService } from '../services/branchService';
-import { StudioService } from '../services/studioService';
+import { Request, Response, NextFunction } from "express";
+import { BranchService } from "../services/branchService";
+import { StudioService } from "../services/studioService";
 
 export class BranchController {
+  static async getAll(req: Request, res: Response, next: NextFunction) {
+    try {
+      const studioId = req.user?.studio_id;
+      // A user without a studio simply has no branches. Answering 404 here
+      // made the admin screen believe the studio itself was missing and
+      // render the "create your studio" onboarding form instead.
+      if (!studioId) {
+        return res.json([]);
+      }
 
-    static async getAll(req: Request, res: Response, next: NextFunction) {
-        try {
-            const studioId = req.user?.studio_id;
-            if (!studioId) {
-                return res.status(404).json({ error: 'Studio not found' });
-            }
-
-            const branches = await BranchService.getAll(studioId);
-            res.json(branches);
-        } catch (error) {
-            next(error);
-        }
+      const branches = await BranchService.getAll(studioId);
+      res.json(branches);
+    } catch (error) {
+      next(error);
     }
+  }
 
-    static async create(req: Request, res: Response, next: NextFunction) {
-        try {
-            const studioId = req.user?.studio_id;
-            const branchData = req.body;
+  static async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const studioId = req.user?.studio_id;
+      const branchData = req.body;
 
-            if (!studioId) {
-                return res.status(404).json({ error: 'Studio not found' });
-            }
+      if (!studioId) {
+        return res.status(404).json({ error: "Studio not found" });
+      }
 
-            const branch = await BranchService.create(studioId, branchData);
-            res.status(201).json(branch);
-        } catch (error) {
-            next(error);
-        }
+      const branch = await BranchService.create(studioId, branchData);
+      res.status(201).json(branch);
+    } catch (error) {
+      next(error);
     }
+  }
 
-    static async update(req: Request, res: Response, next: NextFunction) {
-        try {
-            const studioId = req.user?.studio_id;
-            const { id } = req.params;
-            const updates = req.body;
+  static async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const studioId = req.user?.studio_id;
+      const { id } = req.params;
+      const updates = req.body;
 
-            // Security: Verify studio ownership implies branch ownership
-            if (!studioId) return res.status(403).json({ error: 'Forbidden' });
+      // Security: Verify studio ownership implies branch ownership
+      if (!studioId) return res.status(403).json({ error: "Forbidden" });
 
-            const branch = await BranchService.update(id, studioId, updates);
-            res.json(branch);
-        } catch (error) {
-            next(error);
-        }
+      const branch = await BranchService.update(id, studioId, updates);
+      res.json(branch);
+    } catch (error) {
+      next(error);
     }
+  }
 
-    static async delete(req: Request, res: Response, next: NextFunction) {
-        try {
-            const studioId = req.user?.studio_id;
-            if (!studioId) return res.status(401).json({ error: "Unauthorized" });
-            const { id } = req.params;
+  static async delete(req: Request, res: Response, next: NextFunction) {
+    try {
+      const studioId = req.user?.studio_id;
+      if (!studioId) return res.status(401).json({ error: "Unauthorized" });
+      const { id } = req.params;
 
-            await BranchService.delete(id, studioId);
-            res.status(204).send();
-        } catch (error) {
-            next(error);
-        }
+      await BranchService.delete(id, studioId);
+      res.status(204).send();
+    } catch (error) {
+      next(error);
     }
+  }
 }

--- a/server/src/controllers/studioController.ts
+++ b/server/src/controllers/studioController.ts
@@ -33,19 +33,25 @@ export class StudioController {
       });
     } catch (error: any) {
       requestLog.error({ err: error }, "Error creating studio");
-      if (error.message === "User already has a studio") {
-        return res.status(409).json({ error: error.message });
-      }
+      // AppError('User already has a studio', 409) reaches the client through
+      // errorMiddleware with its own status code.
       next(error);
     }
   }
 
   static async getMyStudio(req: Request, res: Response, next: NextFunction) {
     try {
-      const studioId = req.user?.studio_id;
-      if (!studioId) return res.status(404).json({ message: "No studio found for this user" });
+      const userId = req.user?.id;
+      if (!userId) {
+        return res.status(401).json({ error: "Unauthorized" });
+      }
 
-      const studio = await StudioService.getStudioById(studioId);
+      // Resolves through users.studio_id and falls back to studio ownership,
+      // so a broken link does not look like "this admin has no studio".
+      const studio = await StudioService.getStudioForUser(
+        userId,
+        req.user?.studio_id
+      );
 
       if (!studio) {
         return res
@@ -69,7 +75,10 @@ export class StudioController {
       if (!studioId || studioId !== id) {
         return res
           .status(403)
-          .json({ error: "Forbidden: You do not have permission to update this studio" });
+          .json({
+            error:
+              "Forbidden: You do not have permission to update this studio",
+          });
       }
 
       const updatedStudio = await StudioService.updateStudio(id, updates);

--- a/server/src/services/studioService.ts
+++ b/server/src/services/studioService.ts
@@ -1,4 +1,13 @@
 import { prisma } from "../config/prisma";
+import { AppError } from "../utils/AppError";
+
+/** Branch details collected by the onboarding form. */
+export interface CreateStudioBranchDTO {
+  name?: string;
+  address?: string;
+  city?: string;
+  phone_number?: string;
+}
 
 export interface CreateStudioDTO {
   name: string;
@@ -6,6 +15,9 @@ export interface CreateStudioDTO {
   contact_email?: string;
   contact_phone?: string;
   website_url?: string;
+  /** Sent by the onboarding form (client/components/admin/Administration). */
+  branchData?: CreateStudioBranchDTO;
+  // Flat aliases kept for older callers.
   branch_name?: string;
   address?: string;
   city?: string;
@@ -15,7 +27,10 @@ export interface CreateStudioDTO {
 }
 
 export class StudioService {
-  // Create a new studio + default branch + update user (in a transaction)
+  /** Default room created alongside a branch, mirroring BranchService.create. */
+  private static readonly DEFAULT_ROOM = { name: "אולם ראשי", capacity: 20 };
+
+  // Create a new studio + default branch + default room + update user (in a transaction)
   static async createStudio(adminId: string, data: CreateStudioDTO) {
     // 1. Check if user already has a studio
     const existingStudio = await prisma.studios.findFirst({
@@ -24,8 +39,21 @@ export class StudioService {
     });
 
     if (existingStudio) {
-      throw new Error("User already has a studio");
+      throw new AppError("User already has a studio", 409);
     }
+
+    // The onboarding form nests the branch under `branchData`; older callers
+    // passed the same values as flat fields. Accept both so the details the
+    // admin typed are never silently dropped.
+    const branch: CreateStudioBranchDTO = {
+      name: data.branchData?.name || data.branch_name,
+      address: data.branchData?.address || data.address,
+      city: data.branchData?.city || data.city,
+      phone_number:
+        data.branchData?.phone_number ||
+        data.branch_phone ||
+        data.contact_phone,
+    };
 
     // 2. Use a Prisma transaction to handle the entire operation atomically
     const result = await prisma.$transaction(async (tx) => {
@@ -51,17 +79,34 @@ export class StudioService {
           contact_email: data.contact_email || null,
           contact_phone: data.contact_phone || null,
           website_url: data.website_url || null,
+          ...(data.schedule_start_hour !== undefined && {
+            schedule_start_hour: data.schedule_start_hour,
+          }),
+          ...(data.schedule_end_hour !== undefined && {
+            schedule_end_hour: data.schedule_end_hour,
+          }),
         },
       });
 
       // Create Default Branch
-      await tx.branches.create({
+      const defaultBranch = await tx.branches.create({
         data: {
           studio_id: studio.id,
-          name: data.branch_name || "סניף ראשי",
-          address: data.address || null,
-          city: data.city || null,
-          phone_number: data.branch_phone || data.contact_phone || null,
+          name: branch.name || "סניף ראשי",
+          address: branch.address || null,
+          city: branch.city || null,
+          phone_number: branch.phone_number || null,
+          is_active: true,
+        },
+      });
+
+      // Create Default Room — a branch without a room cannot host any class.
+      await tx.studio_rooms.create({
+        data: {
+          studio_id: studio.id,
+          branch_id: defaultBranch.id,
+          name: StudioService.DEFAULT_ROOM.name,
+          capacity: StudioService.DEFAULT_ROOM.capacity,
           is_active: true,
         },
       });
@@ -101,10 +146,40 @@ export class StudioService {
     return data; // Returns null if not found
   }
 
+  /**
+   * Resolve the studio a user manages, and repair a broken link on the way.
+   *
+   * `users.studio_id` is the normal path, but it can be out of sync with
+   * reality: an admin invited by a SUPER_ADMIN is created with a NULL
+   * studio_id, and deleting a studio nulls the column (ON DELETE SET NULL).
+   * When that happens the user still owns their studio through
+   * `studios.admin_id`, so fall back to ownership and re-link the user —
+   * otherwise the UI offers to create a studio that already exists, and
+   * creating it fails with "User already has a studio".
+   *
+   * Returns null only when the user genuinely has no studio yet.
+   */
+  static async getStudioForUser(userId: string, studioId?: string | null) {
+    if (studioId) {
+      const linked = await this.getStudioById(studioId);
+      if (linked) return linked;
+    }
+
+    const owned = await this.getStudioByAdmin(userId);
+    if (!owned) return null;
+
+    await prisma.users.update({
+      where: { id: userId },
+      data: { studio_id: owned.id },
+    });
+
+    return owned;
+  }
+
   // Update Studio
   static async updateStudio(
     studioId: string,
-    updates: Partial<CreateStudioDTO>,
+    updates: Partial<CreateStudioDTO>
   ) {
     const data = await prisma.studios.update({
       where: { id: studioId },

--- a/server/tests/integration/courses.test.ts
+++ b/server/tests/integration/courses.test.ts
@@ -62,9 +62,9 @@ describe("Course routes", () => {
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual(courses);
-    // Admin: no is_active filter in where clause
+    // Admin: no is_active filter, but always scoped to the caller's studio
     expect(mockPrisma.classes.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: {} })
+      expect.objectContaining({ where: { studio_id: "studio-1" } })
     );
   });
 
@@ -77,7 +77,9 @@ describe("Course routes", () => {
 
     expect(response.status).toBe(200);
     expect(mockPrisma.classes.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { is_active: true } })
+      expect.objectContaining({
+        where: { is_active: true, studio_id: "studio-1" },
+      })
     );
   });
 });

--- a/server/tests/setupEnv.ts
+++ b/server/tests/setupEnv.ts
@@ -1,3 +1,8 @@
 process.env.NODE_ENV = 'test';
 process.env.CLIENT_URL = process.env.CLIENT_URL || 'http://localhost:3000';
 process.env.FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:3000';
+// paymentService constructs a Stripe client at import time, and the Stripe SDK
+// throws on an empty key. Without this every suite that imports the app fails
+// to boot. Stripe itself is mocked wherever it is actually exercised.
+process.env.STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY || 'sk_test_dummy';
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-jwt-secret';

--- a/server/tests/unit/studioService.test.ts
+++ b/server/tests/unit/studioService.test.ts
@@ -1,0 +1,198 @@
+import { StudioService } from "../../src/services/studioService";
+import { prisma } from "../../src/config/prisma";
+import { AppError } from "../../src/utils/AppError";
+
+jest.mock("../../src/config/prisma", () => {
+  const prismaClient: any = {
+    studios: {
+      create: jest.fn(),
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    branches: { create: jest.fn() },
+    studio_rooms: { create: jest.fn() },
+    users: { update: jest.fn() },
+    $queryRaw: jest.fn(),
+    $transaction: jest.fn(async (cb: any) => await cb(prismaClient)),
+  };
+  return { prisma: prismaClient };
+});
+
+const prismaMock = prisma as unknown as {
+  studios: {
+    create: jest.Mock;
+    findFirst: jest.Mock;
+    findUnique: jest.Mock;
+    update: jest.Mock;
+  };
+  branches: { create: jest.Mock };
+  studio_rooms: { create: jest.Mock };
+  users: { update: jest.Mock };
+  $queryRaw: jest.Mock;
+  $transaction: jest.Mock;
+};
+
+const ADMIN_ID = "11111111-1111-1111-1111-111111111111";
+const STUDIO_ID = "22222222-2222-2222-2222-222222222222";
+const BRANCH_ID = "33333333-3333-3333-3333-333333333333";
+
+describe("StudioService.getStudioForUser", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns the studio the user is linked to", async () => {
+    const studio = { id: STUDIO_ID, name: "Studio" };
+    prismaMock.studios.findUnique.mockResolvedValue(studio);
+
+    const result = await StudioService.getStudioForUser(ADMIN_ID, STUDIO_ID);
+
+    expect(result).toEqual(studio);
+    expect(prismaMock.studios.findFirst).not.toHaveBeenCalled();
+    expect(prismaMock.users.update).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the studio the user owns when studio_id is null", async () => {
+    const owned = { id: STUDIO_ID, name: "Studio", admin_id: ADMIN_ID };
+    prismaMock.studios.findFirst.mockResolvedValue(owned);
+
+    const result = await StudioService.getStudioForUser(ADMIN_ID, null);
+
+    expect(result).toEqual(owned);
+    expect(prismaMock.studios.findUnique).not.toHaveBeenCalled();
+    // The broken link is repaired so the next request takes the fast path.
+    expect(prismaMock.users.update).toHaveBeenCalledWith({
+      where: { id: ADMIN_ID },
+      data: { studio_id: STUDIO_ID },
+    });
+  });
+
+  it("falls back to ownership when studio_id points at a missing studio", async () => {
+    const owned = { id: STUDIO_ID, name: "Studio", admin_id: ADMIN_ID };
+    prismaMock.studios.findUnique.mockResolvedValue(null);
+    prismaMock.studios.findFirst.mockResolvedValue(owned);
+
+    const result = await StudioService.getStudioForUser(
+      ADMIN_ID,
+      "44444444-4444-4444-4444-444444444444"
+    );
+
+    expect(result).toEqual(owned);
+    expect(prismaMock.users.update).toHaveBeenCalled();
+  });
+
+  it("returns null when the user has no studio at all", async () => {
+    prismaMock.studios.findUnique.mockResolvedValue(null);
+    prismaMock.studios.findFirst.mockResolvedValue(null);
+
+    const result = await StudioService.getStudioForUser(ADMIN_ID, null);
+
+    expect(result).toBeNull();
+    expect(prismaMock.users.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("StudioService.createStudio", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prismaMock.studios.findFirst.mockResolvedValue(null);
+    prismaMock.$queryRaw.mockResolvedValue([{ nextval: BigInt(7) }]);
+    prismaMock.studios.create.mockResolvedValue({ id: STUDIO_ID });
+    prismaMock.branches.create.mockResolvedValue({ id: BRANCH_ID });
+    prismaMock.studio_rooms.create.mockResolvedValue({ id: "room" });
+    prismaMock.users.update.mockResolvedValue({});
+    prismaMock.studios.findUnique.mockResolvedValue({ id: STUDIO_ID });
+  });
+
+  it("persists the branch details sent by the onboarding form", async () => {
+    await StudioService.createStudio(ADMIN_ID, {
+      name: "יוגה סטודיו",
+      branchData: {
+        name: "תל אביב",
+        address: "הרצל 1",
+        city: "תל אביב",
+        phone_number: "03-1234567",
+      },
+    });
+
+    expect(prismaMock.branches.create).toHaveBeenCalledWith({
+      data: {
+        studio_id: STUDIO_ID,
+        name: "תל אביב",
+        address: "הרצל 1",
+        city: "תל אביב",
+        phone_number: "03-1234567",
+        is_active: true,
+      },
+    });
+  });
+
+  it("still accepts the flat branch fields used by older callers", async () => {
+    await StudioService.createStudio(ADMIN_ID, {
+      name: "יוגה סטודיו",
+      branch_name: "חיפה",
+      address: "הנמל 5",
+      city: "חיפה",
+      branch_phone: "04-7654321",
+    });
+
+    expect(prismaMock.branches.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ name: "חיפה", city: "חיפה" }),
+      })
+    );
+  });
+
+  it("creates a default room for the first branch", async () => {
+    await StudioService.createStudio(ADMIN_ID, { name: "יוגה סטודיו" });
+
+    expect(prismaMock.studio_rooms.create).toHaveBeenCalledWith({
+      data: {
+        studio_id: STUDIO_ID,
+        branch_id: BRANCH_ID,
+        name: "אולם ראשי",
+        capacity: 20,
+        is_active: true,
+      },
+    });
+  });
+
+  it("stores the studio's schedule hours", async () => {
+    await StudioService.createStudio(ADMIN_ID, {
+      name: "יוגה סטודיו",
+      schedule_start_hour: 8,
+      schedule_end_hour: 21,
+    });
+
+    expect(prismaMock.studios.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        schedule_start_hour: 8,
+        schedule_end_hour: 21,
+      }),
+    });
+  });
+
+  it("links the admin to the new studio", async () => {
+    await StudioService.createStudio(ADMIN_ID, { name: "יוגה סטודיו" });
+
+    expect(prismaMock.users.update).toHaveBeenCalledWith({
+      where: { id: ADMIN_ID },
+      data: { studio_id: STUDIO_ID },
+    });
+  });
+
+  it("rejects a second studio with a 409 instead of a 500", async () => {
+    prismaMock.studios.findFirst.mockResolvedValue({ id: STUDIO_ID });
+
+    await expect(
+      StudioService.createStudio(ADMIN_ID, { name: "שני" })
+    ).rejects.toMatchObject({ statusCode: 409 });
+
+    await expect(
+      StudioService.createStudio(ADMIN_ID, { name: "שני" })
+    ).rejects.toBeInstanceOf(AppError);
+
+    expect(prismaMock.studios.create).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What was broken

Signed in as an admin, the **Administration** tab offered to create a first studio and branch, while the Dashboard, Students and Attendance tabs showed the studio's real data (3 students, the Tel Aviv branch and its classes). A newly invited admin submitting that same form got a 500.

Both come from one place. Production logs:

```
GET  /api/studios/my-studio -> The column `studios.schedule_start_hour` does not exist in the current database.
POST /api/studios           -> PrismaClientKnownRequestError P2022 { modelName: 'studios', column: 'schedule_start_hour' }
```

`studio_management_schema_setup.sql` is mounted at `/docker-entrypoint-initdb.d/`, so Postgres runs it **only on an empty data directory**. The two `studios.schedule_*_hour` columns added to it (and to `schema.prisma`) in bf497e2 never reached the live database, and Prisma names every column explicitly in its SQL — so every query touching `studios` fails. Screens that never read `studios` kept working, which is exactly why the app contradicted itself.

The frontend then told the wrong story: `fetchData()` awaited four requests inside one `try`, and left `studio` as `null` on any failure — which is the condition that renders the onboarding form.

## Changes

**Database repair** — `server/prisma/sql/2026-08-16_repair_schema_drift.sql`, idempotent and already applied to production:
- adds any missing column across every table (production was missing 3)
- creates `studio_serial_sequence` and re-aligns it past existing serials
- refreshes the CHECK constraints that gained values later: `schedule_sessions.status` (`IN_PROGRESS`, added the same day in #130) and `enrollments.status` (`PENDING`) — two 500s that had not been hit yet
- the column repair commits before the later sections, and each constraint runs in its own block with an exception handler, so nothing can roll it back
- ends with verification queries (studio columns, admins with a broken studio link)

**Backend**
- `StudioService.getStudioForUser`: resolves through `users.studio_id`, falls back to `studios.admin_id` and re-links the user. An admin invited by a SUPER_ADMIN registers with `studio_id = NULL`, so without this they are stuck between "create a studio" and `User already has a studio`.
- `createStudio`: honours the `branchData` the onboarding form sends (name/address/city/phone were silently dropped), stores the schedule hours, creates the default room in the same transaction, and rejects a second studio with 409 instead of 500.
- `GET /api/branches` returns `[]` instead of 404 when the user has no studio.

**Frontend**
- `Administration` loads the studio on its own and shows the onboarding form only on a genuine 404; any other failure renders an error with retry, and a partial failure of branches/rooms/instructors (now `allSettled`) no longer hides the studio.
- adds the `contact_phone` field missing from the form state; reads API errors from both the `{ error }` and `{ message }` response shapes.

**Test infrastructure** — 4 integration suites could not boot on `main` (no default export in `src/app.ts`, Stripe constructed with an empty key). Restored, and the course assertions updated to the studio-scoped queries from #131.

## Verification

- server: 74 tests / 11 suites pass, `tsc --noEmit` clean
- client: 9 tests pass (4 new ones pin the behaviour — a 500 must not render onboarding), `tsc --noEmit` and `eslint` clean
- repair script parsed with the PostgreSQL grammar (pglast): 26 statements, 3 PL/pgSQL blocks, all 182 generated `ADD COLUMN` definitions
- applied to production: `columns added: 3`, both verification queries returned 0 rows

## Note for reviewers

Merging deploys immediately. The database repair is already done, so this PR is the resilience half: without it a schema drift still shows up as "you have no studio", and the branch details typed during onboarding are still discarded.