### PR TITLE
fix: stop a local checkout from serving the production domain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,7 @@ Conventional commits: `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `test:`.
 - **`register` accepts `studio_serial`** without an invitation, silently creating a `STUDENT` in that studio.
 - **Auth state race condition in `App.tsx`:** `isAuthenticated`, `currentUser`, `userRole` update asynchronously. Default `userRole` is `'STUDENT'` so an admin may briefly see the wrong UI on load.
 - **No CI test gate.** Push to `main` deploys immediately to production via `.github/workflows/deploy.yml`. Treat `main` = production.
+- **Never run `cf-tunnel` outside production.** Cloudflare accepts several connectors per tunnel and load-balances public traffic across them, so a second `docker compose up` holding the production `CF_TUNNEL_TOKEN` starts serving `classly-studio-management.uk` from that machine's database. Symptom: the same login returns a different user on different requests, and half the traffic never reaches the production logs. `docker-compose.override.yml` parks the service behind an unactivated profile so a local checkout cannot do this; the deploy passes `--file docker-compose.yml` only, so production still starts it.
 - **`SUPER_ADMIN` has no provisioning flow** — must be seeded manually with SQL.
 - **`ClassCard` is duplicated** in `common/ClassCard.tsx`, `landing/ClassCard.tsx`, and `student/CourseCard.tsx` — keep changes in sync or consolidate.
 - **No frontend live reload in Docker.** Code changes to the client require `docker compose up -d --build frontend`.

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -3,9 +3,20 @@
 # It is NOT committed to the production server.
 #
 # Changes from docker-compose.yml:
+#   - cf-tunnel: never started locally (see below)
 #   - frontend: mounts nginx.dev.conf (HTTP-only, localhost) over the production config
 #   - frontend/backend/grafana: expose ports on localhost for dev convenience
 services:
+  # Cloudflare allows several connectors on one tunnel and load-balances public
+  # traffic across all of them. A local `docker compose up` with the production
+  # CF_TUNNEL_TOKEN in .env therefore starts serving classly-studio-management.uk
+  # from this machine's database — visitors get whichever instance Cloudflare
+  # picks, and the two disagree about who the logged-in user even is.
+  # An unactivated profile keeps the service defined but never started; the
+  # deploy workflow runs `--file docker-compose.yml` only, so production is
+  # unaffected and still starts the tunnel.
+  cf-tunnel:
+    profiles: ["production-only"]
   frontend:
     ports:
       - "127.0.0.1:3000:80"


### PR DESCRIPTION
Cloudflare accepts several connectors on one tunnel and load-balances public traffic across them. cf-tunnel lives in docker-compose.yml with the production CF_TUNNEL_TOKEN, so any second `docker compose up` — a laptop, an old box — registers another connector and starts answering for classly-studio-management.uk from its own database.

Observed in production: six consecutive logins as admin@admin.com through the domain all returned user 449c5107 with studio a7d4df50, while the server's own database holds exactly one row for that email (4a4cab78, studio 860d73cc, UNIQUE constraint intact) and never logged those requests.

Park cf-tunnel behind an unactivated profile in docker-compose.override.yml, which Compose loads automatically for local runs. Verified with `docker compose config --services`: cf-tunnel is absent locally and still present under `--file docker-compose.yml`, which is what the deploy workflow runs.


Claude-Session: https://claude.ai/code/session_01Efr5KpoWv2h1ov2hv2UoEi