### PR TITLE
fix: schedule hides classes, local checkout hijacks domain, /courses/available leaks studios

### DIFF
--- a/client/components/__tests__/ClassSchedule.test.tsx
+++ b/client/components/__tests__/ClassSchedule.test.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { HelmetProvider } from "react-helmet-async";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import "@testing-library/jest-dom";
+import { ClassSchedule } from "../admin/ClassSchedule";
+import {
+  CourseService,
+  BranchService,
+  RoomService,
+  StudioService,
+} from "../../services/api";
+
+vi.mock("../../services/api", () => ({
+  CourseService: { getAll: vi.fn(), delete: vi.fn() },
+  BranchService: { getAll: vi.fn() },
+  RoomService: { getAll: vi.fn() },
+  StudioService: { getMyStudio: vi.fn() },
+  UserService: { getInstructors: vi.fn(() => Promise.resolve([])) },
+}));
+
+// The modal pulls in its own services and is not what these tests exercise.
+vi.mock("../admin/AddClassModal", () => ({
+  AddClassModal: () => null,
+}));
+
+const BRANCH_ID = "branch-1";
+const ROOM_ID = "room-1";
+
+const branch = { id: BRANCH_ID, name: "תל אביב", studio_id: "s1" };
+const room = {
+  id: ROOM_ID,
+  name: "אולם 1",
+  branch_id: BRANCH_ID,
+  studio_id: "s1",
+  capacity: 20,
+};
+
+const makeClass = (over: Record<string, any>) => ({
+  id: "c-" + Math.random().toString(36).slice(2),
+  name: "שיעור",
+  branch_id: BRANCH_ID,
+  day_of_week: 0,
+  start_time: "1970-01-01T09:00:00.000Z",
+  end_time: "1970-01-01T10:00:00.000Z",
+  max_capacity: 20,
+  current_enrollment: 0,
+  level: "ALL_LEVELS",
+  instructor: { full_name: "מדריך" },
+  ...over,
+});
+
+const renderSchedule = () =>
+  render(
+    <HelmetProvider>
+      <ClassSchedule />
+    </HelmetProvider>
+  );
+
+describe("ClassSchedule room columns", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(BranchService.getAll).mockResolvedValue([branch] as any);
+    vi.mocked(RoomService.getAll).mockResolvedValue([room] as any);
+    vi.mocked(StudioService.getMyStudio).mockResolvedValue({
+      id: "s1",
+      name: "סטודיו",
+      schedule_start_hour: 7,
+      schedule_end_hour: 23,
+    } as any);
+  });
+
+  it("places a class in its room column via room_id", async () => {
+    vi.mocked(CourseService.getAll).mockResolvedValue([
+      makeClass({ name: "יוגה", room_id: ROOM_ID, location_room: "אולם 1" }),
+    ] as any);
+
+    renderSchedule();
+
+    await waitFor(() => expect(screen.getByText("יוגה")).toBeInTheDocument());
+    expect(screen.getByText("אולם 1")).toBeInTheDocument();
+    expect(screen.queryByText("ללא שיבוץ חדר")).not.toBeInTheDocument();
+  });
+
+  it("still shows a legacy class whose room name matches no room", async () => {
+    // The bug this guards: location_room 'אולם ראשי' with no such room meant the
+    // class had no column and disappeared from the schedule entirely.
+    vi.mocked(CourseService.getAll).mockResolvedValue([
+      makeClass({ name: "פילאטיס", room_id: null, location_room: "אולם ראשי" }),
+    ] as any);
+
+    renderSchedule();
+
+    await waitFor(() =>
+      expect(screen.getByText("פילאטיס")).toBeInTheDocument()
+    );
+    expect(screen.getByText("ללא שיבוץ חדר")).toBeInTheDocument();
+  });
+
+  it("matches a legacy class by name when it does line up with a room", async () => {
+    vi.mocked(CourseService.getAll).mockResolvedValue([
+      makeClass({ name: "אופניים", room_id: null, location_room: "אולם 1" }),
+    ] as any);
+
+    renderSchedule();
+
+    await waitFor(() =>
+      expect(screen.getByText("אופניים")).toBeInTheDocument()
+    );
+    expect(screen.queryByText("ללא שיבוץ חדר")).not.toBeInTheDocument();
+  });
+
+  it("shows classes of the selected day only", async () => {
+    vi.mocked(CourseService.getAll).mockResolvedValue([
+      makeClass({ name: "יוגה ראשון", day_of_week: 0, room_id: ROOM_ID }),
+      makeClass({ name: "פילאטיס רביעי", day_of_week: 3, room_id: ROOM_ID }),
+    ] as any);
+
+    renderSchedule();
+
+    await waitFor(() =>
+      expect(screen.getByText("יוגה ראשון")).toBeInTheDocument()
+    );
+    expect(screen.queryByText("פילאטיס רביעי")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "רביעי" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("פילאטיס רביעי")).toBeInTheDocument()
+    );
+    expect(screen.queryByText("יוגה ראשון")).not.toBeInTheDocument();
+  });
+});

--- a/client/components/admin/AddClassModal.tsx
+++ b/client/components/admin/AddClassModal.tsx
@@ -1,345 +1,433 @@
 import React, { useState, useEffect } from "react";
 import { Loader2, Save } from "lucide-react";
-import { CourseService, UserService, BranchService, RoomService } from "../../services/api";
-import { ClassSession, User, Branch, Room, ClassLevel } from "../../types/types";
+import {
+  CourseService,
+  UserService,
+  BranchService,
+  RoomService,
+} from "../../services/api";
+import {
+  ClassSession,
+  User,
+  Branch,
+  Room,
+  ClassLevel,
+} from "../../types/types";
 import { BaseModal } from "../common/BaseModal";
 import { FormInput, FormSelect } from "../common/FormFields";
 import { DAY_MAP, extractTime } from "../../utils/dateUtils";
 
 interface AddClassModalProps {
-    isOpen: boolean;
-    onClose: () => void;
-    onSuccess: (newClass: any) => void;
-    editClass?: ClassSession | null;
-    defaultDay?: number;
-    defaultBranchId?: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: (newClass: any) => void;
+  editClass?: ClassSession | null;
+  defaultDay?: number;
+  defaultBranchId?: string;
 }
 
-export const AddClassModal: React.FC<AddClassModalProps> = ({ isOpen, onClose, onSuccess, editClass, defaultDay, defaultBranchId }) => {
-    const [loading, setLoading] = useState(false);
-    const [instructors, setInstructors] = useState<User[]>([]);
-    const [branches, setBranches] = useState<Branch[]>([]);
-    const [allRooms, setAllRooms] = useState<Room[]>([]);
+export const AddClassModal: React.FC<AddClassModalProps> = ({
+  isOpen,
+  onClose,
+  onSuccess,
+  editClass,
+  defaultDay,
+  defaultBranchId,
+}) => {
+  const [loading, setLoading] = useState(false);
+  const [instructors, setInstructors] = useState<User[]>([]);
+  const [branches, setBranches] = useState<Branch[]>([]);
+  const [allRooms, setAllRooms] = useState<Room[]>([]);
 
-    const [formData, setFormData] = useState({
-        name: '',
-        instructor_id: '',
-        branch_id: '',
-        day_of_week: 0,
-        start_time: '09:00',
-        end_time: '10:00',
-        max_capacity: 20,
-        level: 'ALL_LEVELS'as ClassLevel,
-        price_ils: 0,
-        location_room: 'אולם ראשי'
-    });
+  const [formData, setFormData] = useState({
+    name: "",
+    instructor_id: "",
+    branch_id: "",
+    day_of_week: 0,
+    start_time: "09:00",
+    end_time: "10:00",
+    max_capacity: 20,
+    level: "ALL_LEVELS" as ClassLevel,
+    price_ils: 0,
+    location_room: "אולם ראשי",
+    // room_id is what the schedule grid keys off. location_room is kept in
+    // sync for display and for legacy rows that predate the FK.
+    room_id: "",
+  });
 
-    const [error, setError] = useState<string | null>(null);
-    const [warningConfirmation, setWarningConfirmation] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [warningConfirmation, setWarningConfirmation] = useState<string | null>(
+    null
+  );
 
-    useEffect(() => {
-        if (isOpen) {
-            const fetchData = async () => {
-                try {
-                    const [instructorsData, branchesData, roomsData] = await Promise.all([
-                        UserService.getInstructors(),
-                        BranchService.getAll(),
-                        RoomService.getAll()
-                    ]);
-
-                    setInstructors(instructorsData);
-                    setBranches(branchesData);
-                    setAllRooms(roomsData);
-
-                    // Default selection logic
-                    setFormData(prev => {
-                        const newData = { ...prev };
-                        if (instructorsData.length > 0 && !prev.instructor_id) {
-                            newData.instructor_id = instructorsData[0].id;
-                        }
-                        if (branchesData.length > 0 && !prev.branch_id) {
-                            const branchIdToUse = defaultBranchId && branchesData.some(branch => branch.id === defaultBranchId)
-                                ? defaultBranchId
-                                : branchesData[0].id;
-                                
-                            newData.branch_id = branchIdToUse;
-
-                            // Auto-select room for default branch
-                            const defaultBranchRooms = roomsData.filter(room => room.branch_id === branchIdToUse);
-                            if (defaultBranchRooms.length > 0) {
-                                newData.location_room = defaultBranchRooms[0].name;
-                            }
-                        }
-                        return newData;
-                    });
-                } catch (err) {
-                    console.error("Error fetching form data:", err);
-                }
-            };
-            fetchData();
-        }
-    }, [isOpen]);
-
-    // Pre-fill form when editClass changes
-    useEffect(() => {
-        if (isOpen && editClass) {
-            setFormData({
-                name: editClass.name,
-                instructor_id: editClass.instructor_id || '',
-                branch_id: editClass.branch_id || '',
-                day_of_week: editClass.day_of_week,
-                start_time: extractTime(editClass.start_time),
-                end_time: extractTime(editClass.end_time),
-                max_capacity: editClass.max_capacity,
-                level: editClass.level,
-                price_ils: editClass.price_ils || 0,
-                location_room: editClass.location_room || 'אולם ראשי'
-            });
-        } else if (isOpen && !editClass) {
-            // Reset for create mode — use defaultDay if provided
-            setFormData(prev => ({
-                ...prev,
-                name: '',
-                day_of_week: defaultDay ?? 0,
-                price_ils: 0,
-                start_time: '09:00',
-                end_time: '10:00'
-            }));
-        }
-    }, [isOpen, editClass]);
-
-    // Derived state: Filter rooms based on selected branch
-    const availableRooms = allRooms.filter(room => room.branch_id === formData.branch_id);
-
-    // Create options for selects
-    const branchOptions = branches.map(branch => ({ value: branch.id, label: branch.name }));
-    const instructorOptions = instructors.map(instructor => ({ value: instructor.id, label: instructor.full_name }));
-    const dayOptions = Object.entries(DAY_MAP).map(([key, val]) => ({ value: key, label: val }));
-    const roomOptions = availableRooms.length > 0
-        ? availableRooms.map(room => ({ value: room.name, label: room.name }))
-        : [{ value: 'אולם ראשי', label: 'אולם ראשי (ברירת מחדל)' }];
-
-    const levelOptions = [
-        { value: "ALL_LEVELS", label: "כל הרמות" },
-        { value: "BEGINNER", label: "מתחילים" },
-        { value: "INTERMEDIATE", label: "בינוניים" },
-        { value: "ADVANCED", label: "מתקדמים" },
-    ];
-
-    // Auto-select room when branch changes (client-side only)
-    useEffect(() => {
-        if (formData.branch_id && availableRooms.length > 0) {
-            // Check if current room is valid for this branch, if not, switch to first available
-            const isCurrentRoomValid = availableRooms.some(room => room.name === formData.location_room);
-            if (!isCurrentRoomValid) {
-                setFormData(prev => ({ ...prev, location_room: availableRooms[0].name }));
-            }
-        }
-    }, [formData.branch_id, allRooms]);
-
-
-    const handleSubmit = async (e?: React.FormEvent, forceSave = false) => {
-        if (e) e.preventDefault();
-        setLoading(true);
-        setError(null);
-        setWarningConfirmation(null);
-
+  useEffect(() => {
+    if (isOpen) {
+      const fetchData = async () => {
         try {
-            const newClassPayload = {
-                name: formData.name,
-                instructor_id: formData.instructor_id,
-                branch_id: formData.branch_id,
-                day_of_week: Number(formData.day_of_week) as any,
-                start_time: formData.start_time,
-                end_time: formData.end_time,
-                max_capacity: Number(formData.max_capacity),
-                level: formData.level,
-                price_ils: Number(formData.price_ils),
-                location_room: formData.location_room,
-                is_active: true,
-                ignore_warnings: forceSave
-            };
+          const [instructorsData, branchesData, roomsData] = await Promise.all([
+            UserService.getInstructors(),
+            BranchService.getAll(),
+            RoomService.getAll(),
+          ]);
 
-            let result;
-            if (editClass) {
-                result = await CourseService.update(editClass.id, newClassPayload);
-            } else {
-                result = await CourseService.create(newClassPayload);
+          setInstructors(instructorsData);
+          setBranches(branchesData);
+          setAllRooms(roomsData);
+
+          // Default selection logic
+          setFormData((prev) => {
+            const newData = { ...prev };
+            if (instructorsData.length > 0 && !prev.instructor_id) {
+              newData.instructor_id = instructorsData[0].id;
             }
+            if (branchesData.length > 0 && !prev.branch_id) {
+              const branchIdToUse =
+                defaultBranchId &&
+                branchesData.some((branch) => branch.id === defaultBranchId)
+                  ? defaultBranchId
+                  : branchesData[0].id;
 
-            const instructorObj = instructors.find(instructor => instructor.id === formData.instructor_id);
-            const hydratedClass = {
-                ...result,
-                instructor: { full_name: instructorObj?.full_name || 'לא ידוע' }
-            };
+              newData.branch_id = branchIdToUse;
 
-            onSuccess(hydratedClass);
-            onClose();
-            setFormData(prev => ({ ...prev, name: '', price_ils: 0 }));
-
-        } catch (err: any) {
-            console.error(err);
-            if (err.response?.status === 409) {
-                setWarningConfirmation(err.response?.data?.message || "אזהרה: ישנה התנגשות אפשרית.");
-            } else {
-                setError(err.response?.data?.message || err.response?.data?.error || err.message || "שגיאה ביצירת השיעור");
+              // Auto-select room for default branch
+              const defaultBranchRooms = roomsData.filter(
+                (room) => room.branch_id === branchIdToUse
+              );
+              if (defaultBranchRooms.length > 0) {
+                newData.location_room = defaultBranchRooms[0].name;
+                newData.room_id = defaultBranchRooms[0].id;
+              }
             }
-        } finally {
-            setLoading(false);
+            return newData;
+          });
+        } catch (err) {
+          console.error("Error fetching form data:", err);
         }
-    };
+      };
+      fetchData();
+    }
+  }, [isOpen]);
 
-    const Footer = (
-        <>
-            <button
+  // Pre-fill form when editClass changes
+  useEffect(() => {
+    if (isOpen && editClass) {
+      setFormData({
+        name: editClass.name,
+        instructor_id: editClass.instructor_id || "",
+        branch_id: editClass.branch_id || "",
+        day_of_week: editClass.day_of_week,
+        start_time: extractTime(editClass.start_time),
+        end_time: extractTime(editClass.end_time),
+        max_capacity: editClass.max_capacity,
+        level: editClass.level,
+        price_ils: editClass.price_ils || 0,
+        location_room: editClass.location_room || "אולם ראשי",
+        room_id: editClass.room_id || "",
+      });
+    } else if (isOpen && !editClass) {
+      // Reset for create mode — use defaultDay if provided
+      setFormData((prev) => ({
+        ...prev,
+        name: "",
+        day_of_week: defaultDay ?? 0,
+        price_ils: 0,
+        start_time: "09:00",
+        end_time: "10:00",
+      }));
+    }
+  }, [isOpen, editClass]);
+
+  // Derived state: Filter rooms based on selected branch
+  const availableRooms = allRooms.filter(
+    (room) => room.branch_id === formData.branch_id
+  );
+
+  // Create options for selects
+  const branchOptions = branches.map((branch) => ({
+    value: branch.id,
+    label: branch.name,
+  }));
+  const instructorOptions = instructors.map((instructor) => ({
+    value: instructor.id,
+    label: instructor.full_name,
+  }));
+  const dayOptions = Object.entries(DAY_MAP).map(([key, val]) => ({
+    value: key,
+    label: val,
+  }));
+  const roomOptions =
+    availableRooms.length > 0
+      ? availableRooms.map((room) => ({ value: room.name, label: room.name }))
+      : [{ value: "אולם ראשי", label: "אולם ראשי (ברירת מחדל)" }];
+
+  const levelOptions = [
+    { value: "ALL_LEVELS", label: "כל הרמות" },
+    { value: "BEGINNER", label: "מתחילים" },
+    { value: "INTERMEDIATE", label: "בינוניים" },
+    { value: "ADVANCED", label: "מתקדמים" },
+  ];
+
+  // Auto-select room when branch changes (client-side only)
+  useEffect(() => {
+    if (!formData.branch_id || availableRooms.length === 0) return;
+
+    // A room belongs to exactly one branch, so a room_id from another branch
+    // is not valid here. Legacy classes carry only a name, which may match
+    // no room at all — those fall back to the first room of the branch.
+    const current = formData.room_id
+      ? availableRooms.find((room) => room.id === formData.room_id)
+      : availableRooms.find((room) => room.name === formData.location_room);
+
+    const room = current ?? availableRooms[0];
+    if (room.id !== formData.room_id || room.name !== formData.location_room) {
+      setFormData((prev) => ({
+        ...prev,
+        room_id: room.id,
+        location_room: room.name,
+      }));
+    }
+  }, [formData.branch_id, allRooms]);
+
+  const handleSubmit = async (e?: React.FormEvent, forceSave = false) => {
+    if (e) e.preventDefault();
+    setLoading(true);
+    setError(null);
+    setWarningConfirmation(null);
+
+    try {
+      const newClassPayload = {
+        name: formData.name,
+        instructor_id: formData.instructor_id,
+        branch_id: formData.branch_id,
+        day_of_week: Number(formData.day_of_week) as any,
+        start_time: formData.start_time,
+        end_time: formData.end_time,
+        max_capacity: Number(formData.max_capacity),
+        level: formData.level,
+        price_ils: Number(formData.price_ils),
+        location_room: formData.location_room,
+        room_id: formData.room_id || null,
+        is_active: true,
+        ignore_warnings: forceSave,
+      };
+
+      let result;
+      if (editClass) {
+        result = await CourseService.update(editClass.id, newClassPayload);
+      } else {
+        result = await CourseService.create(newClassPayload);
+      }
+
+      const instructorObj = instructors.find(
+        (instructor) => instructor.id === formData.instructor_id
+      );
+      const hydratedClass = {
+        ...result,
+        instructor: { full_name: instructorObj?.full_name || "לא ידוע" },
+      };
+
+      onSuccess(hydratedClass);
+      onClose();
+      setFormData((prev) => ({ ...prev, name: "", price_ils: 0 }));
+    } catch (err: any) {
+      console.error(err);
+      if (err.response?.status === 409) {
+        setWarningConfirmation(
+          err.response?.data?.message || "אזהרה: ישנה התנגשות אפשרית."
+        );
+      } else {
+        setError(
+          err.response?.data?.message ||
+            err.response?.data?.error ||
+            err.message ||
+            "שגיאה ביצירת השיעור"
+        );
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const Footer = (
+    <>
+      <button
+        type="button"
+        onClick={onClose}
+        className="flex-1 py-2.5 text-slate-600 bg-slate-100 hover:bg-slate-200 rounded-lg font-medium transition-colors dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+      >
+        ביטול
+      </button>
+      <button
+        // Trigger form submit via id or ref effectively?
+        // Since this is outside the form, we need to associate it or wrap form inside BaseModal content better.
+        // Refactor strategy: Put <form> as direct child of modal content,
+        // OR make 'handleSubmit' triggerable.
+        // Easiest for now: Use the form id="addClassForm" and button form="addClassForm"
+        form="addClassForm"
+        type="submit"
+        disabled={loading}
+        className="flex-1 py-2.5 text-white bg-indigo-600 hover:bg-indigo-700 rounded-lg font-medium transition-colors flex items-center justify-center gap-2"
+      >
+        {loading ? (
+          <Loader2 className="animate-spin" size={18} />
+        ) : (
+          <Save size={18} />
+        )}
+        {editClass ? "שמור שינויים" : "שמור שיעור"}
+      </button>
+    </>
+  );
+
+  return (
+    <BaseModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={editClass ? "עריכת פרטי שיעור" : "שיבוץ שיעור חדש"}
+      footer={Footer}
+    >
+      <form id="addClassForm" onSubmit={handleSubmit} className="space-y-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <FormInput
+            label="שם השיעור"
+            required
+            value={formData.name}
+            onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+            placeholder="לדוגמה: יוגה מתחילים"
+          />
+
+          <FormSelect
+            label="סניף"
+            required
+            options={branchOptions}
+            value={formData.branch_id}
+            onChange={(e) =>
+              setFormData({ ...formData, branch_id: e.target.value })
+            }
+            placeholder="בחר סניף"
+          />
+
+          <FormSelect
+            label="מדריך"
+            required
+            options={instructorOptions}
+            value={formData.instructor_id}
+            onChange={(e) =>
+              setFormData({ ...formData, instructor_id: e.target.value })
+            }
+            placeholder="בחר מדריך"
+          />
+
+          <FormSelect
+            label="יום בשבוע"
+            options={dayOptions}
+            value={formData.day_of_week}
+            onChange={(e) =>
+              setFormData({ ...formData, day_of_week: Number(e.target.value) })
+            }
+          />
+
+          <FormSelect
+            label="חדר"
+            required
+            options={roomOptions}
+            value={formData.location_room}
+            onChange={(e) => {
+              const selectedName = e.target.value;
+              const roomObj = availableRooms.find(
+                (room) => room.name === selectedName
+              );
+              setFormData({
+                ...formData,
+                location_room: selectedName,
+                room_id: roomObj ? roomObj.id : "",
+                max_capacity: roomObj
+                  ? roomObj.capacity || 20
+                  : formData.max_capacity,
+              });
+            }}
+            placeholder="בחר חדר"
+          />
+
+          <FormInput
+            label="שעת התחלה"
+            type="time"
+            required
+            value={formData.start_time}
+            onChange={(e) =>
+              setFormData({ ...formData, start_time: e.target.value })
+            }
+          />
+
+          <FormInput
+            label="שעת סיום"
+            type="time"
+            required
+            value={formData.end_time}
+            onChange={(e) =>
+              setFormData({ ...formData, end_time: e.target.value })
+            }
+          />
+
+          <FormSelect
+            label="רמה"
+            options={levelOptions}
+            value={formData.level}
+            onChange={(e) =>
+              setFormData({ ...formData, level: e.target.value as any })
+            }
+          />
+
+          <FormInput
+            label="מכסה מקסימלית"
+            type="number"
+            min="1"
+            required
+            value={formData.max_capacity}
+            onChange={(e) =>
+              setFormData({ ...formData, max_capacity: Number(e.target.value) })
+            }
+          />
+
+          <FormInput
+            label="מחיר (₪)"
+            type="number"
+            min="0"
+            required
+            value={formData.price_ils}
+            onChange={(e) =>
+              setFormData({ ...formData, price_ils: Number(e.target.value) })
+            }
+          />
+        </div>
+
+        {error && (
+          <div className="text-red-500 text-sm bg-red-50 p-2 rounded dark:bg-red-500/10 dark:text-red-400">
+            {error}
+          </div>
+        )}
+
+        {warningConfirmation && (
+          <div className="text-orange-700 text-sm bg-orange-50 p-3 rounded border border-orange-200 flex flex-col gap-2 dark:bg-orange-500/10 dark:text-orange-400 dark:border-orange-500/20">
+            <span>{warningConfirmation}</span>
+            <div className="flex gap-2 mt-1">
+              <button
                 type="button"
-                onClick={onClose}
-                className="flex-1 py-2.5 text-slate-600 bg-slate-100 hover:bg-slate-200 rounded-lg font-medium transition-colors dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
-            >
+                onClick={() => handleSubmit(undefined, true)}
+                className="bg-orange-600 text-white px-3 py-1.5 rounded-md text-xs font-medium hover:bg-orange-700 transition-colors"
+              >
+                שמור בכל זאת
+              </button>
+              <button
+                type="button"
+                onClick={() => setWarningConfirmation(null)}
+                className="text-orange-600 px-3 py-1.5 text-xs font-medium hover:bg-orange-100 rounded-md transition-colors dark:hover:bg-orange-500/20"
+              >
                 ביטול
-            </button>
-            <button
-                // Trigger form submit via id or ref effectively? 
-                // Since this is outside the form, we need to associate it or wrap form inside BaseModal content better.
-                // Refactor strategy: Put <form> as direct child of modal content, 
-                // OR make 'handleSubmit' triggerable. 
-                // Easiest for now: Use the form id="addClassForm" and button form="addClassForm"
-                form="addClassForm"
-                type="submit"
-                disabled={loading}
-                className="flex-1 py-2.5 text-white bg-indigo-600 hover:bg-indigo-700 rounded-lg font-medium transition-colors flex items-center justify-center gap-2"
-            >
-                {loading ? <Loader2 className="animate-spin" size={18} /> : <Save size={18} />}
-                {editClass ? 'שמור שינויים' : 'שמור שיעור'}
-            </button>
-        </>
-    );
-
-    return (
-        <BaseModal
-            isOpen={isOpen}
-            onClose={onClose}
-            title={editClass ? 'עריכת פרטי שיעור' : 'שיבוץ שיעור חדש'}
-            footer={Footer}
-        >
-            <form id="addClassForm" onSubmit={handleSubmit} className="space-y-4">
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <FormInput
-                        label="שם השיעור"
-                        required
-                        value={formData.name}
-                        onChange={e => setFormData({ ...formData, name: e.target.value })}
-                        placeholder="לדוגמה: יוגה מתחילים"
-                    />
-
-                    <FormSelect
-                        label="סניף"
-                        required
-                        options={branchOptions}
-                        value={formData.branch_id}
-                        onChange={e => setFormData({ ...formData, branch_id: e.target.value })}
-                        placeholder="בחר סניף"
-                    />
-
-                    <FormSelect
-                        label="מדריך"
-                        required
-                        options={instructorOptions}
-                        value={formData.instructor_id}
-                        onChange={e => setFormData({ ...formData, instructor_id: e.target.value })}
-                        placeholder="בחר מדריך"
-                    />
-
-                    <FormSelect
-                        label="יום בשבוע"
-                        options={dayOptions}
-                        value={formData.day_of_week}
-                        onChange={e => setFormData({ ...formData, day_of_week: Number(e.target.value) })}
-                    />
-
-                    <FormSelect
-                        label="חדר"
-                        required
-                        options={roomOptions}
-                        value={formData.location_room}
-                        onChange={e => {
-                            const selectedName = e.target.value;
-                            const roomObj = availableRooms.find(room => room.name === selectedName);
-                            setFormData({
-                                ...formData,
-                                location_room: selectedName,
-                                max_capacity: roomObj ? (roomObj.capacity || 20) : formData.max_capacity
-                            });
-                        }}
-                        placeholder="בחר חדר"
-                    />
-
-                    <FormInput
-                        label="שעת התחלה"
-                        type="time"
-                        required
-                        value={formData.start_time}
-                        onChange={e => setFormData({ ...formData, start_time: e.target.value })}
-                    />
-
-                    <FormInput
-                        label="שעת סיום"
-                        type="time"
-                        required
-                        value={formData.end_time}
-                        onChange={e => setFormData({ ...formData, end_time: e.target.value })}
-                    />
-
-                    <FormSelect
-                        label="רמה"
-                        options={levelOptions}
-                        value={formData.level}
-                        onChange={e => setFormData({ ...formData, level: e.target.value as any })}
-                    />
-
-                    <FormInput
-                        label="מכסה מקסימלית"
-                        type="number"
-                        min="1"
-                        required
-                        value={formData.max_capacity}
-                        onChange={e => setFormData({ ...formData, max_capacity: Number(e.target.value) })}
-                    />
-
-                    <FormInput
-                        label="מחיר (₪)"
-                        type="number"
-                        min="0"
-                        required
-                        value={formData.price_ils}
-                        onChange={e => setFormData({ ...formData, price_ils: Number(e.target.value) })}
-                    />
-                </div>
-
-                {error && <div className="text-red-500 text-sm bg-red-50 p-2 rounded dark:bg-red-500/10 dark:text-red-400">{error}</div>}
-
-                {warningConfirmation && (
-                    <div className="text-orange-700 text-sm bg-orange-50 p-3 rounded border border-orange-200 flex flex-col gap-2 dark:bg-orange-500/10 dark:text-orange-400 dark:border-orange-500/20">
-                        <span>{warningConfirmation}</span>
-                        <div className="flex gap-2 mt-1">
-                            <button 
-                                type="button" 
-                                onClick={() => handleSubmit(undefined, true)} 
-                                className="bg-orange-600 text-white px-3 py-1.5 rounded-md text-xs font-medium hover:bg-orange-700 transition-colors"
-                            >
-                                שמור בכל זאת
-                            </button>
-                            <button 
-                                type="button" 
-                                onClick={() => setWarningConfirmation(null)} 
-                                className="text-orange-600 px-3 py-1.5 text-xs font-medium hover:bg-orange-100 rounded-md transition-colors dark:hover:bg-orange-500/20"
-                            >
-                                ביטול
-                            </button>
-                        </div>
-                    </div>
-                )}
-            </form>
-        </BaseModal>
-    );
+              </button>
+            </div>
+          </div>
+        )}
+      </form>
+    </BaseModal>
+  );
 };

--- a/client/components/admin/ClassSchedule.tsx
+++ b/client/components/admin/ClassSchedule.tsx
@@ -9,7 +9,12 @@ import {
   ChevronLeft,
   Loader2,
 } from "lucide-react";
-import { CourseService, BranchService, RoomService, StudioService } from "../../services/api";
+import {
+  CourseService,
+  BranchService,
+  RoomService,
+  StudioService,
+} from "../../services/api";
 import { ClassSession, Branch, Room, Studio } from "../../types/types";
 import { AddClassModal } from "./AddClassModal";
 import { ClassCard } from "../common/ClassCard";
@@ -31,8 +36,9 @@ export const ClassSchedule: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingClass, setEditingClass] = useState<ClassSession | null>(null);
-  const [selectedViewClass, setSelectedViewClass] = useState<ClassSession | null>(null);
-  
+  const [selectedViewClass, setSelectedViewClass] =
+    useState<ClassSession | null>(null);
+
   const [filterTeacher, setFilterTeacher] = useState("all");
   const [filterLevel, setFilterLevel] = useState("all");
 
@@ -62,6 +68,7 @@ export const ClassSchedule: React.FC = () => {
       capacity: cls.max_capacity,
       level: cls.level,
       room: cls.location_room || "אולם ראשי",
+      room_id: cls.room_id ?? null,
       categoryName: cls.category?.name,
       bgColor: colorMapper.getBranchColor(cls.branch_id || "default"),
       sideColor: colorMapper.getRoomColor(cls.location_room || "אולם ראשי"),
@@ -74,12 +81,13 @@ export const ClassSchedule: React.FC = () => {
   const fetchClassesAndBranches = async () => {
     try {
       setLoading(true);
-      const [coursesData, branchesData, roomsData, studioData] = await Promise.all([
-        CourseService.getAll({ status: "active" }),
-        BranchService.getAll(),
-        RoomService.getAll(),
-        StudioService.getMyStudio()
-      ]);
+      const [coursesData, branchesData, roomsData, studioData] =
+        await Promise.all([
+          CourseService.getAll({ status: "active" }),
+          BranchService.getAll(),
+          RoomService.getAll(),
+          StudioService.getMyStudio(),
+        ]);
 
       if (studioData) {
         setStudio(studioData);
@@ -112,22 +120,55 @@ export const ClassSchedule: React.FC = () => {
   }, []);
 
   const filteredClasses = classes
-    .filter((cls) => cls.dayOfWeek === selectedDay && (!selectedBranchId || cls.branch_id === selectedBranchId))
-    .filter((cls) => filterTeacher === "all" || cls.instructor === filterTeacher)
+    .filter(
+      (cls) =>
+        cls.dayOfWeek === selectedDay &&
+        (!selectedBranchId || cls.branch_id === selectedBranchId)
+    )
+    .filter(
+      (cls) => filterTeacher === "all" || cls.instructor === filterTeacher
+    )
     .filter((cls) => filterLevel === "all" || cls.level === filterLevel)
     .sort((a, b) => a.startTime.localeCompare(b.startTime));
 
-  const uniqueTeachers = Array.from(new Set(classes.map(c => c.instructor))).filter(Boolean);
-  const uniqueLevels = Array.from(new Set(classes.map(c => c.level))).filter(Boolean);
+  const uniqueTeachers = Array.from(
+    new Set(classes.map((c) => c.instructor))
+  ).filter(Boolean);
+  const uniqueLevels = Array.from(new Set(classes.map((c) => c.level))).filter(
+    Boolean
+  );
 
-  const branchRooms = allRooms.filter(room => room.branch_id === selectedBranchId);
+  const branchRooms = allRooms.filter(
+    (room) => room.branch_id === selectedBranchId
+  );
 
-  const columns = branchRooms.map(room => ({
-    id: room.id,
+  // room_id is authoritative; classes created before it was persisted carry only
+  // the free-text location_room, so fall back to matching that against the room
+  // name for them.
+  const belongsToRoom = (cls: any, room: Room) =>
+    cls.room_id ? cls.room_id === room.id : cls.room === room.name;
+
+  const columns = branchRooms.map((room) => ({
+    id: room.id as string,
     name: room.name,
     icon: <MapPin size={14} className="text-indigo-500" />,
-    classes: filteredClasses.filter(cls => cls.room === room.name)
+    classes: filteredClasses.filter((cls) => belongsToRoom(cls, room)),
   }));
+
+  // A class whose room matches nothing (renamed room, deleted room, or a branch
+  // with no rooms at all) must never disappear from the schedule without a trace.
+  const unassignedClasses = filteredClasses.filter(
+    (cls) => !branchRooms.some((room) => belongsToRoom(cls, room))
+  );
+
+  if (unassignedClasses.length > 0) {
+    columns.push({
+      id: "__unassigned__",
+      name: "ללא שיבוץ חדר",
+      icon: <MapPin size={14} className="text-amber-500" />,
+      classes: unassignedClasses,
+    });
+  }
 
   // Calendar configuration
   const START_HOUR = studio?.schedule_start_hour ?? 7;
@@ -168,7 +209,9 @@ export const ClassSchedule: React.FC = () => {
           setClasses((prev) => {
             const exists = prev.some((cls) => cls.id === formatted.id);
             if (exists) {
-              return prev.map((cls) => (cls.id === formatted.id ? formatted : cls));
+              return prev.map((cls) =>
+                cls.id === formatted.id ? formatted : cls
+              );
             }
             return [...prev, formatted];
           });
@@ -244,23 +287,37 @@ export const ClassSchedule: React.FC = () => {
             <Filter size={18} />
             <span className="font-medium text-sm hidden md:inline">סינון:</span>
           </div>
-          
+
           <select
             value={filterTeacher}
-            onChange={e => setFilterTeacher(e.target.value)}
+            onChange={(e) => setFilterTeacher(e.target.value)}
             className="flex-1 md:w-auto text-sm bg-white border border-slate-200 rounded-lg px-3 py-2 focus:outline-none focus:border-indigo-500 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200 shadow-sm"
           >
             <option value="all">כל המדריכים</option>
-            {uniqueTeachers.map(t => <option key={t} value={t}>{t}</option>)}
+            {uniqueTeachers.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
           </select>
 
           <select
             value={filterLevel}
-            onChange={e => setFilterLevel(e.target.value)}
+            onChange={(e) => setFilterLevel(e.target.value)}
             className="flex-1 md:w-auto text-sm bg-white border border-slate-200 rounded-lg px-3 py-2 focus:outline-none focus:border-indigo-500 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200 shadow-sm"
           >
             <option value="all">כל הרמות</option>
-            {uniqueLevels.map(l => <option key={l} value={l}>{l === 'BEGINNER' ? 'מתחילים' : l === 'INTERMEDIATE' ? 'בינוניים' : l === 'ADVANCED' ? 'מתקדמים' : l}</option>)}
+            {uniqueLevels.map((l) => (
+              <option key={l} value={l}>
+                {l === "BEGINNER"
+                  ? "מתחילים"
+                  : l === "INTERMEDIATE"
+                    ? "בינוניים"
+                    : l === "ADVANCED"
+                      ? "מתקדמים"
+                      : l}
+              </option>
+            ))}
           </select>
         </div>
       </div>

--- a/client/types/types.ts
+++ b/client/types/types.ts
@@ -64,7 +64,10 @@ export interface ClassSession {
   max_capacity: number;
   current_enrollment: number;
   level: ClassLevel;
+  /** Free-text room label. Legacy rows may hold a name no room actually has. */
   location_room?: string | null;
+  /** FK to studio_rooms — the authoritative room link. Null on legacy rows. */
+  room_id?: string | null;
   price_ils: number;
   is_active: boolean;
   category_id?: string | null;

--- a/server/prisma/sql/2026-08-16_backfill_class_room_id.sql
+++ b/server/prisma/sql/2026-08-16_backfill_class_room_id.sql
@@ -1,0 +1,55 @@
+-- ============================================================================
+-- Backfill classes.room_id from the free-text location_room. Safe to re-run.
+--
+-- WHY
+-- classes.room_id is the FK to studio_rooms, but AddClassModal only ever sent
+-- location_room (free text), so every existing row has room_id = NULL. The
+-- admin schedule grid builds its columns from the studio's rooms and matched
+-- classes by comparing location_room to the room *name*, so a class whose name
+-- matched nothing silently vanished from the schedule while still appearing in
+-- the course list and in attendance.
+--
+-- This links every class that can be linked: same studio, same branch, and a
+-- location_room equal to the room's name (whitespace-insensitive). Rows that
+-- match no room are left alone — the grid now shows them under a
+-- "ללא שיבוץ חדר" column instead of dropping them.
+--
+-- HOW TO RUN (from the repo root on the server):
+--   docker exec -i classly-db psql -U itay -d classly_db -v ON_ERROR_STOP=1 \
+--     < server/prisma/sql/2026-08-16_backfill_class_room_id.sql
+--
+-- Nothing is deleted and location_room is left untouched.
+-- ============================================================================
+
+BEGIN;
+
+\echo '--- classes with no room link, before ---'
+SELECT count(*) AS unlinked_before FROM public.classes WHERE room_id IS NULL;
+
+UPDATE public.classes c
+SET room_id = r.id
+FROM public.studio_rooms r
+WHERE c.room_id IS NULL
+  AND r.studio_id = c.studio_id
+  AND r.branch_id = c.branch_id
+  AND btrim(r.name) = btrim(c.location_room);
+
+\echo '--- classes with no room link, after (these show under "ללא שיבוץ חדר") ---'
+SELECT count(*) AS unlinked_after FROM public.classes WHERE room_id IS NULL;
+
+COMMIT;
+
+-- ---------------------------------------------------------------------------
+-- What is left unlinked, and why: the location_room value has no matching room
+-- in that branch. Either create a room with that name or reassign the class.
+-- ---------------------------------------------------------------------------
+SELECT c.name AS class_name,
+       c.day_of_week,
+       c.start_time,
+       c.location_room,
+       b.name AS branch
+FROM public.classes c
+LEFT JOIN public.branches b ON b.id = c.branch_id
+WHERE c.room_id IS NULL
+  AND c.is_active
+ORDER BY b.name, c.day_of_week, c.start_time;

--- a/server/src/controllers/courseController.ts
+++ b/server/src/controllers/courseController.ts
@@ -40,7 +40,10 @@ export class CourseController {
     requestLog.info({ userId: req.user!.id }, "Controller entry");
     try {
       const studentId = req.user!.id;
-      const courses = await CourseService.getAvailableForStudent(studentId);
+      const courses = await CourseService.getAvailableForStudent(
+        studentId,
+        req.studioId
+      );
       requestLog.info(
         { count: courses?.length },
         "Fetched available courses for student"

--- a/server/src/services/courseService.ts
+++ b/server/src/services/courseService.ts
@@ -74,15 +74,22 @@ export class CourseService {
   /**
    * Get available courses for student (active & not fully booked)
    */
-  static async getAvailableForStudent(studentId: string) {
+  static async getAvailableForStudent(studentId: string, studioId?: string) {
     const serviceLogger = logger.child({
       service: "CourseService",
       method: "getAvailableForStudent",
     });
-    serviceLogger.info({ studentId }, "Fetching available courses for student");
+    serviceLogger.info({ studentId, studioId }, "Fetching available courses for student");
+
+    // Tenant isolation: without a studio context there is nothing scoped to
+    // list. Without this guard the query below returns active classes across
+    // every studio in the system.
+    if (!studioId) {
+      return [];
+    }
 
     const data = await prisma.classes.findMany({
-      where: { is_active: true },
+      where: { is_active: true, studio_id: studioId },
       include: {
         instructor: {
           select: { full_name: true },

--- a/server/src/services/courseService.ts
+++ b/server/src/services/courseService.ts
@@ -79,7 +79,10 @@ export class CourseService {
       service: "CourseService",
       method: "getAvailableForStudent",
     });
-    serviceLogger.info({ studentId, studioId }, "Fetching available courses for student");
+    serviceLogger.info(
+      { studentId, studioId },
+      "Fetching available courses for student"
+    );
 
     // Tenant isolation: without a studio context there is nothing scoped to
     // list. Without this guard the query below returns active classes across
@@ -143,8 +146,8 @@ export class CourseService {
       orderBy: { day_of_week: "asc" },
       include: {
         branch: { select: { name: true } },
-        category: { select: { name: true } }
-      }
+        category: { select: { name: true } },
+      },
     });
 
     return data;
@@ -166,29 +169,42 @@ export class CourseService {
         where: {
           studio_id: studioId,
           instructor_id: courseData.instructor_id as string,
-          is_active: true
-        }
+          is_active: true,
+        },
       });
-      const instructorConflict = checkScheduleConflict(courseData as any, instructorClasses);
+      const instructorConflict = checkScheduleConflict(
+        courseData as any,
+        instructorClasses
+      );
       if (instructorConflict.hasConflict) {
         throw new AppError("המורה כבר מלמד שיעור אחר בשעה זו", 400);
       }
       if (instructorConflict.hasWarning && !courseData.ignore_warnings) {
-        throw new AppError(instructorConflict.warnings?.join("\n") || "אזהרה: המדריך משובץ בסניף אחר.", 409);
+        throw new AppError(
+          instructorConflict.warnings?.join("\n") ||
+            "אזהרה: המדריך משובץ בסניף אחר.",
+          409
+        );
       }
     }
 
-    // 2. Room Conflict Check
-    if (courseData.location_room && branchId) {
+    // 2. Room Conflict Check — by room_id when the caller supplied one, since a
+    // room can be renamed while the FK stays correct.
+    if (branchId && (courseData.room_id || courseData.location_room)) {
       const roomClasses = await prisma.classes.findMany({
         where: {
           studio_id: studioId,
           branch_id: branchId,
-          location_room: courseData.location_room as string,
-          is_active: true
-        }
+          is_active: true,
+          ...(courseData.room_id
+            ? { room_id: courseData.room_id as string }
+            : { location_room: courseData.location_room as string }),
+        },
       });
-      const roomConflict = checkScheduleConflict(courseData as any, roomClasses);
+      const roomConflict = checkScheduleConflict(
+        courseData as any,
+        roomClasses
+      );
       if (roomConflict.hasConflict) {
         throw new AppError("החדר כבר תפוס בשעה זו", 400);
       }
@@ -234,8 +250,9 @@ export class CourseService {
       end_time: updates.end_time ?? existing.end_time,
       instructor_id: updates.instructor_id ?? existing.instructor_id,
       location_room: updates.location_room ?? existing.location_room,
+      room_id: updates.room_id ?? existing.room_id,
       branch_id: updates.branch_id ?? existing.branch_id,
-      studio_id: existing.studio_id
+      studio_id: existing.studio_id,
     };
 
     // 1. Instructor Conflict Check
@@ -244,29 +261,44 @@ export class CourseService {
         where: {
           studio_id: proposedSession.studio_id,
           instructor_id: proposedSession.instructor_id as string,
-          is_active: true
-        }
+          is_active: true,
+        },
       });
-      const instructorConflict = checkScheduleConflict(proposedSession as any, instructorClasses);
+      const instructorConflict = checkScheduleConflict(
+        proposedSession as any,
+        instructorClasses
+      );
       if (instructorConflict.hasConflict) {
         throw new AppError("המורה כבר מלמד שיעור אחר בשעה זו", 400);
       }
       if (instructorConflict.hasWarning && !updates.ignore_warnings) {
-        throw new AppError(instructorConflict.warnings?.join("\n") || "אזהרה: המדריך משובץ בסניף אחר.", 409);
+        throw new AppError(
+          instructorConflict.warnings?.join("\n") ||
+            "אזהרה: המדריך משובץ בסניף אחר.",
+          409
+        );
       }
     }
 
-    // 2. Room Conflict Check
-    if (proposedSession.location_room && proposedSession.branch_id) {
+    // 2. Room Conflict Check — prefer the FK over the free-text room name.
+    if (
+      proposedSession.branch_id &&
+      (proposedSession.room_id || proposedSession.location_room)
+    ) {
       const roomClasses = await prisma.classes.findMany({
         where: {
           studio_id: proposedSession.studio_id,
           branch_id: proposedSession.branch_id as string,
-          location_room: proposedSession.location_room as string,
-          is_active: true
-        }
+          is_active: true,
+          ...(proposedSession.room_id
+            ? { room_id: proposedSession.room_id as string }
+            : { location_room: proposedSession.location_room as string }),
+        },
       });
-      const roomConflict = checkScheduleConflict(proposedSession as any, roomClasses);
+      const roomConflict = checkScheduleConflict(
+        proposedSession as any,
+        roomClasses
+      );
       if (roomConflict.hasConflict) {
         throw new AppError("החדר כבר תפוס בשעה זו", 400);
       }

--- a/server/tests/unit/courseService.test.ts
+++ b/server/tests/unit/courseService.test.ts
@@ -1,0 +1,68 @@
+import { CourseService } from "../../src/services/courseService";
+import { prisma } from "../../src/config/prisma";
+
+jest.mock("../../src/config/prisma", () => ({
+  prisma: {
+    classes: {
+      findMany: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("../../src/logger", () => ({
+  logger: {
+    child: () => ({
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    }),
+  },
+}));
+
+const prismaMock = prisma as unknown as {
+  classes: { findMany: jest.Mock };
+};
+
+const STUDENT_ID = "11111111-1111-1111-1111-111111111111";
+const STUDIO_ID = "22222222-2222-2222-2222-222222222222";
+
+describe("CourseService.getAvailableForStudent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns [] and never queries the DB when studioId is missing", async () => {
+    const result = await CourseService.getAvailableForStudent(STUDENT_ID);
+
+    expect(result).toEqual([]);
+    expect(prismaMock.classes.findMany).not.toHaveBeenCalled();
+  });
+
+  it("scopes the query to the student's studio", async () => {
+    prismaMock.classes.findMany.mockResolvedValue([
+      { id: "c1", max_capacity: 10, current_enrollment: 3 },
+    ]);
+
+    await CourseService.getAvailableForStudent(STUDENT_ID, STUDIO_ID);
+
+    expect(prismaMock.classes.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { is_active: true, studio_id: STUDIO_ID },
+      })
+    );
+  });
+
+  it("filters out classes that are already full", async () => {
+    prismaMock.classes.findMany.mockResolvedValue([
+      { id: "open", max_capacity: 10, current_enrollment: 3 },
+      { id: "full", max_capacity: 10, current_enrollment: 10 },
+    ]);
+
+    const result = await CourseService.getAvailableForStudent(
+      STUDENT_ID,
+      STUDIO_ID
+    );
+
+    expect(result.map((c: any) => c.id)).toEqual(["open"]);
+  });
+});

--- a/server/tests/unit/courseServiceRooms.test.ts
+++ b/server/tests/unit/courseServiceRooms.test.ts
@@ -1,0 +1,151 @@
+import { CourseService } from "../../src/services/courseService";
+import { prisma } from "../../src/config/prisma";
+
+jest.mock("../../src/config/prisma", () => ({
+  prisma: {
+    classes: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("../../src/logger", () => ({
+  logger: {
+    child: () => ({
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    }),
+  },
+}));
+
+const prismaMock = prisma as unknown as {
+  classes: {
+    findMany: jest.Mock;
+    findUnique: jest.Mock;
+    create: jest.Mock;
+    update: jest.Mock;
+  };
+};
+
+const STUDIO_ID = "11111111-1111-1111-1111-111111111111";
+const BRANCH_ID = "22222222-2222-2222-2222-222222222222";
+const ROOM_ID = "33333333-3333-3333-3333-333333333333";
+const CLASS_ID = "44444444-4444-4444-4444-444444444444";
+
+const baseCourse = {
+  studio_id: STUDIO_ID,
+  branch_id: BRANCH_ID,
+  name: "יוגה",
+  day_of_week: 0,
+  start_time: "09:00",
+  end_time: "10:00",
+  max_capacity: 20,
+  price_ils: 0,
+};
+
+/** The room-conflict lookup is the second findMany call (after the instructor one). */
+const roomLookupArgs = () => prismaMock.classes.findMany.mock.calls.at(-1)?.[0];
+
+describe("CourseService.createCourse room linking", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prismaMock.classes.findMany.mockResolvedValue([]);
+    prismaMock.classes.create.mockResolvedValue({ id: CLASS_ID });
+  });
+
+  it("persists room_id so the schedule can key off the FK", async () => {
+    await CourseService.createCourse({
+      ...baseCourse,
+      location_room: "אולם 1",
+      room_id: ROOM_ID,
+    });
+
+    expect(prismaMock.classes.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        room_id: ROOM_ID,
+        location_room: "אולם 1",
+      }),
+    });
+  });
+
+  it("checks room conflicts by room_id when one is supplied", async () => {
+    await CourseService.createCourse({
+      ...baseCourse,
+      location_room: "אולם 1",
+      room_id: ROOM_ID,
+    });
+
+    expect(roomLookupArgs().where).toEqual(
+      expect.objectContaining({ room_id: ROOM_ID })
+    );
+    expect(roomLookupArgs().where).not.toHaveProperty("location_room");
+  });
+
+  it("falls back to the room name when no room_id is supplied", async () => {
+    await CourseService.createCourse({
+      ...baseCourse,
+      location_room: "אולם ראשי",
+    });
+
+    expect(roomLookupArgs().where).toEqual(
+      expect.objectContaining({ location_room: "אולם ראשי" })
+    );
+    expect(roomLookupArgs().where).not.toHaveProperty("room_id");
+  });
+});
+
+describe("CourseService.updateCourse room linking", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prismaMock.classes.findMany.mockResolvedValue([]);
+    prismaMock.classes.update.mockResolvedValue({ id: CLASS_ID });
+    prismaMock.classes.findUnique.mockResolvedValue({
+      id: CLASS_ID,
+      studio_id: STUDIO_ID,
+      branch_id: BRANCH_ID,
+      day_of_week: 0,
+      start_time: new Date("1970-01-01T09:00:00.000Z"),
+      end_time: new Date("1970-01-01T10:00:00.000Z"),
+      instructor_id: null,
+      location_room: "אולם ראשי",
+      room_id: null,
+    });
+  });
+
+  it("links a legacy class to a room when one is chosen", async () => {
+    await CourseService.updateCourse(CLASS_ID, {
+      location_room: "אולם 1",
+      room_id: ROOM_ID,
+    });
+
+    expect(prismaMock.classes.update).toHaveBeenCalledWith({
+      where: { id: CLASS_ID },
+      data: expect.objectContaining({ room_id: ROOM_ID }),
+    });
+  });
+
+  it("keeps the existing room_id when the update does not mention it", async () => {
+    prismaMock.classes.findUnique.mockResolvedValue({
+      id: CLASS_ID,
+      studio_id: STUDIO_ID,
+      branch_id: BRANCH_ID,
+      day_of_week: 0,
+      start_time: new Date("1970-01-01T09:00:00.000Z"),
+      end_time: new Date("1970-01-01T10:00:00.000Z"),
+      instructor_id: null,
+      location_room: "אולם 1",
+      room_id: ROOM_ID,
+    });
+
+    await CourseService.updateCourse(CLASS_ID, { name: "יוגה מתקדמים" });
+
+    // The conflict lookup still scopes to the room the class already sits in.
+    expect(roomLookupArgs().where).toEqual(
+      expect.objectContaining({ room_id: ROOM_ID })
+    );
+  });
+});


### PR DESCRIPTION
Draft — **not to be merged until after the project presentation.** Merging to `main` deploys immediately and none of this is urgent.

## 1. The schedule silently hid classes

`ClassSchedule` built its columns from the studio's rooms and placed a class in a column only when `location_room` equalled the room's **name**. A class whose name matched no room had nowhere to go and disappeared — no error, no counter, no trace — while still appearing in the course list, in attendance, and to students.

Live example from production: 7 active classes in "dances and life", 6 of them carrying `location_room = 'אולם ראשי'` while the studio's only room is `'אולם 1'`. The schedule showed exactly one class (Sunday yoga), yet attendance had enrollments for Tuesday and Wednesday classes the schedule never displayed.

```
      name       | day_of_week | location_room | room_id
-----------------+-------------+---------------+---------
 יוגה            |           0 | אולם 1        |
 יוגהה           |           1 | אולם ראשי     |
 כושר עצבני      |           1 | אולם ראשי     |
 יוגה מתחילים    |           2 | אולם ראשי     |
 אופניים         |           2 | אולם ראשי     |
 פילאטיס         |           3 | אולם ראשי     |
 פילאטיס מכשירים |           4 | אולם ראשי     |
```

Root cause: `classes.room_id` — the FK to `studio_rooms` — exists in the schema, but `AddClassModal` never sent it, so it is `NULL` on every row and the UI had nothing but free text to match on. `'אולם ראשי'` itself comes from the hardcoded default in the modal's initial state, saved verbatim back when the studio had no rooms at all.

**Changes**
- `AddClassModal` tracks and submits `room_id` alongside `location_room`, keeping the two in sync as the branch or room selection changes
- `ClassSchedule` matches on `room_id`, falls back to the name only for legacy rows without an FK, and renders a **"ללא שיבוץ חדר"** column so a class can never vanish silently again — this also covers a branch with no rooms yet, which previously rendered an empty grid
- `createCourse` / `updateCourse` check room conflicts by `room_id` when present, so renaming a room no longer breaks conflict detection
- `server/prisma/sql/2026-08-16_backfill_class_room_id.sql` — idempotent backfill that links existing classes to rooms by name and reports the rows that still have no match
- `ClassSession` gains `room_id`

## 2. A local checkout could hijack the production domain

Cloudflare allows several connectors on one tunnel and load-balances public traffic across them. `cf-tunnel` lives in `docker-compose.yml` with the production `CF_TUNNEL_TOKEN`, so any second `docker compose up` registers another connector and starts answering for `classly-studio-management.uk` from its own database.

This happened live: six consecutive logins as `admin@admin.com` through the domain all returned user `449c5107` / studio `a7d4df50`, while the production database holds exactly one row for that email (`4a4cab78`, studio `860d73cc`, `UNIQUE(email)` intact) and never logged those requests. The domain even served a different asset bundle (`index-JH2r8Pb3.js`) than `classly-web` had on disk (`index-DIF0THKK.js`). The tell that identified the culprit: the domain's `Set-Cookie` had no `Secure` flag, and `secure` is `process.env.NODE_ENV === "production"` — so the origin answering was a dev stack. Resolved operationally by refreshing the tunnel token.

**Change**: `cf-tunnel` is parked behind an unactivated Compose profile in `docker-compose.override.yml`, which Compose loads automatically for local runs. Verified with `docker compose config --services`: absent locally, still present under `--file docker-compose.yml` (what the deploy workflow runs).

## 3. `GET /api/courses/available` leaked across studios

`CourseService.getAvailableForStudent` queried `classes` with only `is_active: true` — no `studio_id` — so a student calling it saw active classes from every studio in the system. Same shape as the leaks tracked in `docs/ARCHITECTURE_REVIEW.md`, just not one of the ones listed there. Nothing in the UI calls this endpoint today (`BrowseCourses` uses the already-scoped `CourseService.getAll`), but the route is live and callable with any student session.

## Verification

- server: 82 tests / 13 suites pass (10 new), `tsc --noEmit` clean
- client: 13 tests pass (4 new), `tsc --noEmit` clean, `eslint` 0 errors
- the two grid tests that matter — legacy class with an unmatched room name, and day-tab switching — were confirmed to **fail** against the previous code by stashing the fix and re-running
- both SQL scripts parsed with the PostgreSQL grammar (pglast)

## After merging

Run the backfill once so existing classes get their FK:

```bash
docker exec -i classly-db psql -U itay -d classly_db -v ON_ERROR_STOP=1 \
  < server/prisma/sql/2026-08-16_backfill_class_room_id.sql
```

It prints how many classes are still unlinked and lists them — those need either a room with that name or a reassignment.